### PR TITLE
Clean up unit tests and fix intermittent issue with structure set draft lock renewer timer

### DIFF
--- a/docs/releaseHistory.md
+++ b/docs/releaseHistory.md
@@ -4,6 +4,12 @@
 
 All releases in the v0.x.x series are subject to breaking changes from one version to another.  After the release of v1.0.0, this project will be subject to [semantic versioning](http://semver.org/).
 
+## v0.0.22
+
+*Bug fixes*
+- Ensure that structure set draft lock renewer timer does not fire after edit lock has been removed
+- Refactored, standardized, and optimized unit tests
+
 ## v0.0.21
 
 *New Features and Enhancements*

--- a/docs/releaseHistory.md
+++ b/docs/releaseHistory.md
@@ -6,9 +6,12 @@ All releases in the v0.x.x series are subject to breaking changes from one versi
 
 ## v0.0.22
 
+*Enhancements*
+- Refactor and fix possible threading issues in unit tests
+- Replace use of generic ApplicationException with more specific InvalidOperationError
+
 *Bug fixes*
-- Ensure that structure set draft lock renewer timer does not fire after edit lock has been removed
-- Refactored, standardized, and optimized unit tests
+- Ensure that a structure set draft lock renewer timer does not fire after the edit lock has been removed
 
 ## v0.0.21
 

--- a/proknow-sdk-test/Collection/CollectionItemTest.cs
+++ b/proknow-sdk-test/Collection/CollectionItemTest.cs
@@ -17,11 +17,8 @@ namespace ProKnow.Collection.Test
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test collections, if necessary
-            await TestHelper.DeleteCollectionsAsync(_testClassName);
-
-            // Delete test workspaces, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_testClassName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
         }
 
         [ClassCleanup]

--- a/proknow-sdk-test/Collection/CollectionPatientSummaryTest.cs
+++ b/proknow-sdk-test/Collection/CollectionPatientSummaryTest.cs
@@ -17,11 +17,8 @@ namespace ProKnow.Collection.Test
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test collections, if necessary
-            await TestHelper.DeleteCollectionsAsync(_testClassName);
-
-            // Delete test workspaces, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_testClassName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
         }
 
         [ClassCleanup]

--- a/proknow-sdk-test/Collection/CollectionPatientsTest.cs
+++ b/proknow-sdk-test/Collection/CollectionPatientsTest.cs
@@ -18,11 +18,8 @@ namespace ProKnow.Collection.Test
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test collections, if necessary
-            await TestHelper.DeleteCollectionsAsync(_testClassName);
-
-            // Delete test workspaces, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_testClassName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
         }
 
         [ClassCleanup]

--- a/proknow-sdk-test/Collection/CollectionSummaryTest.cs
+++ b/proknow-sdk-test/Collection/CollectionSummaryTest.cs
@@ -1,10 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ProKnow.Patient;
 using ProKnow.Test;
-using ProKnow.Upload;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace ProKnow.Collection.Test
@@ -12,81 +9,55 @@ namespace ProKnow.Collection.Test
     [TestClass]
     public class CollectionSummaryTest
     {
-        private static readonly string _baseName = "SDK-CollectionSummaryTest";
+        private static readonly string _testClassName = nameof(CollectionSummaryTest);
         private static readonly ProKnowApi _proKnow = TestSettings.ProKnow;
-        private static readonly Uploads _uploads = _proKnow.Uploads;
-        private static string _workspaceId;
-        private static CollectionItem _collectionItem;
-        private static CollectionSummary _collectionSummary;
 
         [ClassInitialize]
 #pragma warning disable IDE0060 // Remove unused parameter
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test collections, if necessary
-            await TestHelper.DeleteCollectionsAsync(_baseName);
-
-            // Delete test workspace, if necessary
-            await TestHelper.DeleteWorkspaceAsync(_baseName);
-
-            // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_baseName);
-            _workspaceId = workspaceItem.Id;
-
-            // Create a test patient
-            var patientSummary = await TestHelper.CreatePatientAsync(_baseName);
-
-            // Upload test files
-            var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Becker^Matthew");
-            var overrides = new UploadFileOverrides
-            {
-                Patient = new PatientCreateSchema { Name = _baseName, Mrn = _baseName }
-            };
-            await _uploads.UploadAsync(_workspaceId, uploadPath, overrides);
-
-            // Wait until uploaded test files have processed
-            while (true)
-            {
-                var patientItem = await patientSummary.GetAsync();
-                var entitySummaries = patientItem.FindEntities(e => e.PatientId == patientSummary.Id);
-                if (entitySummaries.Count() >= 4)
-                {
-                    var statuses = entitySummaries.Select(e => e.Status).Distinct();
-                    if (statuses.Count() == 1 && statuses.First() == "completed")
-                    {
-                        break;
-                    }
-                }
-            }
-
-            // Create a test collection
-            _collectionItem = await _proKnow.Collections.CreateAsync($"{_baseName}-Name", $"{_baseName}-Description",
-                "workspace", new List<string>() { _workspaceId });
-            var collectionSummaries = await _proKnow.Collections.QueryAsync(_workspaceId);
-            _collectionSummary = collectionSummaries[0];
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
         }
 
         [ClassCleanup]
         public static async Task ClassCleanup()
         {
             // Delete test collection
-            await _proKnow.Collections.DeleteAsync(_collectionItem.Id);
+            await TestHelper.DeleteCollectionsAsync(_testClassName);
 
             // Delete test workspace
-            await _proKnow.Workspaces.DeleteAsync(_workspaceId);
+            await TestHelper.DeleteWorkspacesAsync(_testClassName);
         }
 
         [TestMethod]
         public async Task GetAsyncTest()
         {
-            var collectionItem = await _collectionSummary.GetAsync();
-            Assert.AreEqual(_collectionItem.Id, collectionItem.Id);
-            Assert.AreEqual(_collectionItem.Name, collectionItem.Name);
-            Assert.AreEqual(_collectionItem.Description, collectionItem.Description);
-            Assert.AreEqual(_collectionItem.Type, collectionItem.Type);
-            Assert.AreEqual(1, collectionItem.WorkspaceIds.Count);
-            Assert.AreEqual(_workspaceId, collectionItem.WorkspaceIds[0]);
+            var testNumber = 1;
+
+            // Create a test workspace
+            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+
+            // Create a test patient
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RD.dcm"), 1);
+
+            // Create a test collection
+            var collectionItem = await _proKnow.Collections.CreateAsync($"{_testClassName}-{testNumber}-Name", $"{_testClassName}-{testNumber}-Description",
+                "workspace", new List<string>() { workspaceItem.Id });
+            var collectionSummaries = await _proKnow.Collections.QueryAsync(workspaceItem.Id);
+            var collectionSummary = collectionSummaries[0];
+
+            // Get the collection from the collection summary
+            var collectionItem2 = await collectionSummary.GetAsync();
+
+            // Verify the returned collection
+            Assert.AreEqual(collectionItem.Id, collectionItem2.Id);
+            Assert.AreEqual(collectionItem.Name, collectionItem2.Name);
+            Assert.AreEqual(collectionItem.Description, collectionItem2.Description);
+            Assert.AreEqual(collectionItem.Type, collectionItem2.Type);
+            Assert.AreEqual(1, collectionItem2.WorkspaceIds.Count);
+            Assert.AreEqual(workspaceItem.Id, collectionItem2.WorkspaceIds[0]);
         }
     }
 }

--- a/proknow-sdk-test/PatientTest/EntitiesTest/DoseItemTest.cs
+++ b/proknow-sdk-test/PatientTest/EntitiesTest/DoseItemTest.cs
@@ -8,22 +8,18 @@ namespace ProKnow.Patient.Entities.Test
     [TestClass]
     public class DoseItemTest
     {
-        private static readonly string _patientMrnAndName = "SDK-DoseItemTest";
-        private static readonly string _downloadFolderRoot = Path.Combine(Path.GetTempPath(), _patientMrnAndName);
+        private static readonly string _testClassName = nameof(DoseItemTest);
+        private static readonly string _downloadFolderRoot = Path.Combine(Path.GetTempPath(), _testClassName);
 
         [ClassInitialize]
 #pragma warning disable IDE0060 // Remove unused parameter
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test workspace, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
 
             // Create download folder root
-            if (Directory.Exists(_downloadFolderRoot))
-            {
-                Directory.Delete(_downloadFolderRoot, true);
-            }
             Directory.CreateDirectory(_downloadFolderRoot);
         }
 
@@ -31,7 +27,7 @@ namespace ProKnow.Patient.Entities.Test
         public static async Task ClassCleanup()
         {
             // Delete test workspaces
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            await TestHelper.DeleteWorkspacesAsync(_testClassName);
 
             // Delete download folder
             if (Directory.Exists(_downloadFolderRoot))
@@ -46,10 +42,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 1;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "RD.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RD.dcm"), 1);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "dose");
             var doseItem = await entitySummaries[0].GetAsync() as DoseItem;
 
@@ -73,10 +69,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 2;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "RD.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RD.dcm"), 1);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "dose");
             var doseItem = await entitySummaries[0].GetAsync() as DoseItem;
 
@@ -101,10 +97,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 3;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "RD.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RD.dcm"), 1);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "dose");
             var doseItem = await entitySummaries[0].GetAsync() as DoseItem;
 
@@ -127,10 +123,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 4;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "RD.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RD.dcm"), 1);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "dose");
             var doseItem = await entitySummaries[0].GetAsync() as DoseItem;
 

--- a/proknow-sdk-test/PatientTest/EntitiesTest/EntityItemTest.cs
+++ b/proknow-sdk-test/PatientTest/EntitiesTest/EntityItemTest.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ProKnow.Test;
-using ProKnow.Upload;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -18,11 +17,8 @@ namespace ProKnow.Patient.Entities.Test
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete existing custom metrics, if necessary
-            await TestHelper.DeleteCustomMetricsAsync(_testClassName);
-
-            // Delete test workspaces, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_testClassName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
         }
 
         [ClassCleanup]
@@ -41,7 +37,7 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 1;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with a plan
             var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RP.dcm"), 1);
@@ -69,7 +65,7 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 2;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with a dose
             var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RD.dcm"), 1);
@@ -96,7 +92,7 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 3;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with a structure set
             var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
@@ -128,7 +124,7 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 4;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set
             var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "CT"), 1);

--- a/proknow-sdk-test/PatientTest/EntitiesTest/EntityItemTest.cs
+++ b/proknow-sdk-test/PatientTest/EntitiesTest/EntityItemTest.cs
@@ -48,15 +48,9 @@ namespace ProKnow.Patient.Entities.Test
             await planItem.DeleteAsync();
 
             // Verify it was deleted
-            while (true)
-            {
-                await patientItem.RefreshAsync();
-                entitySummaries = patientItem.FindEntities(t => t.Type == "plan");
-                if (entitySummaries.Count == 0)
-                {
-                    break;
-                }
-            }
+            await patientItem.RefreshAsync();
+            entitySummaries = patientItem.FindEntities(t => t.Type == "plan");
+            Assert.AreEqual(0, entitySummaries.Count);
         }
 
         [TestMethod]

--- a/proknow-sdk-test/PatientTest/EntitiesTest/EntityScorecardsTest.cs
+++ b/proknow-sdk-test/PatientTest/EntitiesTest/EntityScorecardsTest.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ProKnow.Scorecard;
 using ProKnow.Test;
-using ProKnow.Upload;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
@@ -14,56 +13,42 @@ namespace ProKnow.Patient.Entities.Test
     public class EntityScorecardsTest
     {
         private static readonly ProKnowApi _proKnow = TestSettings.ProKnow;
-        private static readonly string _patientMrnAndName = "SDK-EntityScorecardsTest";
-        private static string _workspaceId;
-        private static EntitySummary _entitySummary;
-        private static EntityScorecards _entityScorecards;
-        private static ComputedMetric _computedMetric;
-        private static CustomMetricItem _customMetricItem;
-        private static List<ComputedMetric> _computedMetrics;
-        private static List<CustomMetric> _customMetrics;
-        private static EntityScorecardItem _entityScorecardItem;
+        private static readonly string _testClassName = nameof(EntityScorecardsTest);
 
         [TestInitialize]
         public async Task ClassInitialize()
         {
-            // Cleanup from previous test failure, if necessary
-            await TestHelper.DeleteWorkspaceAsync(_patientMrnAndName);
-            await TestHelper.DeleteCustomMetricsAsync(_patientMrnAndName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
+        }
+
+        [TestCleanup]
+        public async Task ClassCleanup()
+        {
+            // Delete test workspaces
+            await TestHelper.DeleteWorkspacesAsync(_testClassName);
+
+            // Delete existing custom metrics
+            await TestHelper.DeleteCustomMetricsAsync(_testClassName);
+        }
+
+        [TestMethod]
+        public async Task CreateAsyncTest()
+        {
+            var testNumber = 1;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName);
-            _workspaceId = workspaceItem.Id;
+            var workspace = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
-            // Create a test patient
-            var patientSummary = await TestHelper.CreatePatientAsync(_patientMrnAndName);
-
-            // Upload test file
-            var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Becker^Matthew", "RD.dcm");
-            var overrides = new UploadFileOverrides
-            {
-                Patient = new PatientCreateSchema { Name = _patientMrnAndName, Mrn = _patientMrnAndName }
-            };
-            await _proKnow.Uploads.UploadAsync(_workspaceId, uploadPath, overrides);
-
-            // Wait until uploaded test file has processed
-            while (true)
-            {
-                var patientItem = await patientSummary.GetAsync();
-                var entitySummaries = patientItem.FindEntities(t => t.Type == "dose");
-                if (entitySummaries.Count > 0 && entitySummaries[0].Status == "completed")
-                {
-                    _entitySummary = entitySummaries[0];
-                    await _entitySummary.GetAsync();
-                    break;
-                }
-            }
+            // Create a test patient with a dose
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RD.dcm"), 1);
+            var entitySummary = patientItem.FindEntities(e => e.Type == "dose")[0];
 
             // Create entity scorecards object
-            _entityScorecards = new EntityScorecards(_proKnow, _workspaceId, _entitySummary.Id);
+            var entityScorecards = new EntityScorecards(_proKnow, workspace.Id, entitySummary.Id);
 
-            // Create computed metric for testing
-            _computedMetric = new ComputedMetric("VOLUME_PERCENT_DOSE_RANGE_ROI", "PTV", 30, 60,
+            // Create computed metric
+            var computedMetric = new ComputedMetric("VOLUME_PERCENT_DOSE_RANGE_ROI", "PTV", 30, 60,
                 new List<MetricBin>() {
                     new MetricBin("IDEAL", new byte[] { Color.Green.R, Color.Green.G, Color.Green.B }),
                     new MetricBin("GOOD", new byte[] { Color.LightGreen.R, Color.LightGreen.G, Color.LightGreen.B }, 20),
@@ -72,136 +57,279 @@ namespace ProKnow.Patient.Entities.Test
                     new MetricBin("UNACCEPTABLE", new byte[] { Color.Red.R, Color.Red.G, Color.Red.B })
                 });
 
-            // Create custom metric for testing
-            _customMetricItem = await _proKnow.CustomMetrics.CreateAsync(_patientMrnAndName, "dose", "number");
+            // Create custom metric
+            var customMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}", "dose", "number");
 
             // Add objectives to custom metric
-            var objectives = new List<MetricBin>()
+            customMetricItem.Objectives = new List<MetricBin>()
             {
                 new MetricBin("PASS", new byte[] { 18, 191, 0 }, null, 90),
                 new MetricBin("FAIL", new byte[] { 255, 0, 0 })
             };
-            _customMetricItem.Objectives = objectives;
 
             // Convert custom metric to schema expected by CreateAsync (name and objectives only)
-            var customMetric = new CustomMetric(_patientMrnAndName, objectives);
+            var customMetric = new CustomMetric(customMetricItem.Name, customMetricItem.Objectives);
 
-            // Create entity scorecard for testing
-            _computedMetrics = new List<ComputedMetric>() { _computedMetric };
-            _customMetrics = new List<CustomMetric>() { customMetric };
-            _entityScorecardItem = await _entityScorecards.CreateAsync(_patientMrnAndName, _computedMetrics, _customMetrics);
-        }
+            // Create entity scorecard
+            var computedMetrics = new List<ComputedMetric>() { computedMetric };
+            var customMetrics = new List<CustomMetric>() { customMetric };
+            var entityScorecardItem = await entityScorecards.CreateAsync($"{_testClassName}-{testNumber}", computedMetrics, customMetrics);
 
-        [TestCleanup]
-        public async Task ClassCleanup()
-        {
-            // Delete test workspace
-            await _proKnow.Workspaces.DeleteAsync(_workspaceId);
-
-            // Delete custom metrics created for this test
-            await TestHelper.DeleteCustomMetricsAsync(_patientMrnAndName);
-        }
-
-        [TestMethod]
-        public void CreateAsyncTest()
-        {
-            // Verify creation of entity scorecard in test initialization
-            Assert.AreEqual(_patientMrnAndName, _entityScorecardItem.Name);
-            Assert.AreEqual(1, _entityScorecardItem.ComputedMetrics.Count);
-            var computedMetric = _entityScorecardItem.ComputedMetrics[0];
-            Assert.AreEqual(_computedMetric.Type, computedMetric.Type);
-            Assert.AreEqual(_computedMetric.RoiName, computedMetric.RoiName);
-            Assert.AreEqual(_computedMetric.Arg1, computedMetric.Arg1);
-            Assert.AreEqual(_computedMetric.Arg2, computedMetric.Arg2);
-            Assert.AreEqual(_computedMetric.Objectives.Count, computedMetric.Objectives.Count);
-            for (var i = 0; i < _computedMetric.Objectives.Count; i++)
+            // Verify created entity scorecard
+            Assert.AreEqual($"{_testClassName}-{testNumber}", entityScorecardItem.Name);
+            Assert.AreEqual(1, entityScorecardItem.ComputedMetrics.Count);
+            var createdComputedMetric = entityScorecardItem.ComputedMetrics[0];
+            Assert.AreEqual(computedMetric.Type, createdComputedMetric.Type);
+            Assert.AreEqual(computedMetric.RoiName, createdComputedMetric.RoiName);
+            Assert.AreEqual(computedMetric.Arg1, createdComputedMetric.Arg1);
+            Assert.AreEqual(computedMetric.Arg2, createdComputedMetric.Arg2);
+            Assert.AreEqual(computedMetric.Objectives.Count, createdComputedMetric.Objectives.Count);
+            for (var i = 0; i < createdComputedMetric.Objectives.Count; i++)
             {
-                Assert.AreEqual(_computedMetric.Objectives[i].Label, computedMetric.Objectives[i].Label);
-                Assert.AreEqual(_computedMetric.Objectives[i].Color[0], computedMetric.Objectives[i].Color[0]);
-                Assert.AreEqual(_computedMetric.Objectives[i].Color[1], computedMetric.Objectives[i].Color[1]);
-                Assert.AreEqual(_computedMetric.Objectives[i].Color[2], computedMetric.Objectives[i].Color[2]);
-                Assert.AreEqual(_computedMetric.Objectives[i].Min, computedMetric.Objectives[i].Min);
-                Assert.AreEqual(_computedMetric.Objectives[i].Max, computedMetric.Objectives[i].Max);
+                Assert.AreEqual(computedMetric.Objectives[i].Label, createdComputedMetric.Objectives[i].Label);
+                Assert.AreEqual(computedMetric.Objectives[i].Color[0], createdComputedMetric.Objectives[i].Color[0]);
+                Assert.AreEqual(computedMetric.Objectives[i].Color[1], createdComputedMetric.Objectives[i].Color[1]);
+                Assert.AreEqual(computedMetric.Objectives[i].Color[2], createdComputedMetric.Objectives[i].Color[2]);
+                Assert.AreEqual(computedMetric.Objectives[i].Min, createdComputedMetric.Objectives[i].Min);
+                Assert.AreEqual(computedMetric.Objectives[i].Max, createdComputedMetric.Objectives[i].Max);
             }
-            Assert.AreEqual(1, _entityScorecardItem.CustomMetrics.Count);
-            var customMetricItem = _entityScorecardItem.CustomMetrics[0];
-            Assert.AreEqual(_customMetricItem.Id, customMetricItem.Id);
-            Assert.AreEqual(_customMetricItem.Objectives.Count, customMetricItem.Objectives.Count);
-            for (var i = 0; i < _customMetricItem.Objectives.Count; i++)
+            Assert.AreEqual(1, entityScorecardItem.CustomMetrics.Count);
+            var createdCustomMetricItem = entityScorecardItem.CustomMetrics[0];
+            Assert.AreEqual(customMetricItem.Id, createdCustomMetricItem.Id);
+            Assert.AreEqual(customMetricItem.Objectives.Count, createdCustomMetricItem.Objectives.Count);
+            for (var i = 0; i < createdCustomMetricItem.Objectives.Count; i++)
             {
-                Assert.AreEqual(_customMetricItem.Objectives[i].Label, customMetricItem.Objectives[i].Label);
-                Assert.AreEqual(_customMetricItem.Objectives[i].Color[0], customMetricItem.Objectives[i].Color[0]);
-                Assert.AreEqual(_customMetricItem.Objectives[i].Color[1], customMetricItem.Objectives[i].Color[1]);
-                Assert.AreEqual(_customMetricItem.Objectives[i].Color[2], customMetricItem.Objectives[i].Color[2]);
-                Assert.AreEqual(_customMetricItem.Objectives[i].Min, customMetricItem.Objectives[i].Min);
-                Assert.AreEqual(_customMetricItem.Objectives[i].Max, customMetricItem.Objectives[i].Max);
+                Assert.AreEqual(customMetricItem.Objectives[i].Label, createdCustomMetricItem.Objectives[i].Label);
+                Assert.AreEqual(customMetricItem.Objectives[i].Color[0], createdCustomMetricItem.Objectives[i].Color[0]);
+                Assert.AreEqual(customMetricItem.Objectives[i].Color[1], createdCustomMetricItem.Objectives[i].Color[1]);
+                Assert.AreEqual(customMetricItem.Objectives[i].Color[2], createdCustomMetricItem.Objectives[i].Color[2]);
+                Assert.AreEqual(customMetricItem.Objectives[i].Min, createdCustomMetricItem.Objectives[i].Min);
+                Assert.AreEqual(customMetricItem.Objectives[i].Max, createdCustomMetricItem.Objectives[i].Max);
             }
         }
 
         [TestMethod]
         public async Task DeleteAsyncTest()
         {
+            var testNumber = 2;
+
+            // Create a test workspace
+            var workspace = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+
+            // Create a test patient with a dose
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RD.dcm"), 1);
+            var entitySummary = patientItem.FindEntities(e => e.Type == "dose")[0];
+
+            // Create entity scorecards object
+            var entityScorecards = new EntityScorecards(_proKnow, workspace.Id, entitySummary.Id);
+
+            // Create computed metric
+            var computedMetric = new ComputedMetric("VOLUME_PERCENT_DOSE_RANGE_ROI", "PTV", 30, 60,
+                new List<MetricBin>() {
+                    new MetricBin("IDEAL", new byte[] { Color.Green.R, Color.Green.G, Color.Green.B }),
+                    new MetricBin("GOOD", new byte[] { Color.LightGreen.R, Color.LightGreen.G, Color.LightGreen.B }, 20),
+                    new MetricBin("ACCEPTABLE", new byte[] { Color.Yellow.R, Color.Yellow.G, Color.Yellow.B }, 40, 60),
+                    new MetricBin("MARGINAL", new byte[] { Color.Orange.R, Color.Orange.G, Color.Orange.B }, null, 80),
+                    new MetricBin("UNACCEPTABLE", new byte[] { Color.Red.R, Color.Red.G, Color.Red.B })
+                });
+
+            // Create custom metric
+            var customMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}", "dose", "number");
+
+            // Add objectives to custom metric
+            customMetricItem.Objectives = new List<MetricBin>()
+            {
+                new MetricBin("PASS", new byte[] { 18, 191, 0 }, null, 90),
+                new MetricBin("FAIL", new byte[] { 255, 0, 0 })
+            };
+
+            // Convert custom metric to schema expected by CreateAsync (name and objectives only)
+            var customMetric = new CustomMetric(customMetricItem.Name, customMetricItem.Objectives);
+
+            // Create entity scorecard
+            var computedMetrics = new List<ComputedMetric>() { computedMetric };
+            var customMetrics = new List<CustomMetric>() { customMetric };
+            var entityScorecardItem = await entityScorecards.CreateAsync($"{_testClassName}-{testNumber}", computedMetrics, customMetrics);
+
             // Delete the entity scorecard created in initialization
-            await _entityScorecards.DeleteAsync(_entityScorecardItem.Id);
+            await entityScorecards.DeleteAsync(entityScorecardItem.Id);
 
             // Verify the entity scorecard was deleted
-            var entityScorecardSummary = await _entityScorecards.FindAsync(t => t.Name == _patientMrnAndName);
+            var entityScorecardSummary = await entityScorecards.FindAsync(t => t.Name == _testClassName);
             Assert.IsNull(entityScorecardSummary);
-
-            // Restore the deleted entity scorecard
-            _entityScorecardItem = await _entityScorecards.CreateAsync(_patientMrnAndName, _computedMetrics, _customMetrics);
         }
 
         [TestMethod]
         public async Task FindAsyncTest()
         {
-            var entityScorecardSummary = await _entityScorecards.FindAsync(t => t.Name == _patientMrnAndName);
-            Assert.AreEqual(_entityScorecardItem.Id, entityScorecardSummary.Id);
-            Assert.AreEqual(_entityScorecardItem.Name, entityScorecardSummary.Name);
+            var testNumber = 3;
+
+            // Create a test workspace
+            var workspace = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+
+            // Create a test patient with a dose
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RD.dcm"), 1);
+            var entitySummary = patientItem.FindEntities(e => e.Type == "dose")[0];
+
+            // Create entity scorecards object
+            var entityScorecards = new EntityScorecards(_proKnow, workspace.Id, entitySummary.Id);
+
+            // Create computed metric
+            var computedMetric = new ComputedMetric("VOLUME_PERCENT_DOSE_RANGE_ROI", "PTV", 30, 60,
+                new List<MetricBin>() {
+                    new MetricBin("IDEAL", new byte[] { Color.Green.R, Color.Green.G, Color.Green.B }),
+                    new MetricBin("GOOD", new byte[] { Color.LightGreen.R, Color.LightGreen.G, Color.LightGreen.B }, 20),
+                    new MetricBin("ACCEPTABLE", new byte[] { Color.Yellow.R, Color.Yellow.G, Color.Yellow.B }, 40, 60),
+                    new MetricBin("MARGINAL", new byte[] { Color.Orange.R, Color.Orange.G, Color.Orange.B }, null, 80),
+                    new MetricBin("UNACCEPTABLE", new byte[] { Color.Red.R, Color.Red.G, Color.Red.B })
+                });
+
+            // Create custom metric
+            var customMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}", "dose", "number");
+
+            // Add objectives to custom metric
+            customMetricItem.Objectives = new List<MetricBin>()
+            {
+                new MetricBin("PASS", new byte[] { 18, 191, 0 }, null, 90),
+                new MetricBin("FAIL", new byte[] { 255, 0, 0 })
+            };
+
+            // Convert custom metric to schema expected by CreateAsync (name and objectives only)
+            var customMetric = new CustomMetric(customMetricItem.Name, customMetricItem.Objectives);
+
+            // Create entity scorecard
+            var computedMetrics = new List<ComputedMetric>() { computedMetric };
+            var customMetrics = new List<CustomMetric>() { customMetric };
+            var entityScorecardItem = await entityScorecards.CreateAsync($"{_testClassName}-{testNumber}", computedMetrics, customMetrics);
+
+            var entityScorecardSummary = await entityScorecards.FindAsync(t => t.Name == $"{_testClassName}-{testNumber}");
+            Assert.AreEqual(entityScorecardItem.Id, entityScorecardSummary.Id);
+            Assert.AreEqual(entityScorecardItem.Name, entityScorecardSummary.Name);
         }
 
         [TestMethod]
         public async Task GetAsyncTest()
         {
-            var entityScorecardItem = await _entityScorecards.GetAsync(_entityScorecardItem.Id);
-            Assert.AreEqual(_patientMrnAndName, entityScorecardItem.Name);
-            Assert.AreEqual(1, entityScorecardItem.ComputedMetrics.Count);
-            var computedMetric = entityScorecardItem.ComputedMetrics[0];
-            Assert.AreEqual(_computedMetric.Type, computedMetric.Type);
-            Assert.AreEqual(_computedMetric.RoiName, computedMetric.RoiName);
-            Assert.AreEqual(_computedMetric.Arg1, computedMetric.Arg1);
-            Assert.AreEqual(_computedMetric.Arg2, computedMetric.Arg2);
-            Assert.AreEqual(_computedMetric.Objectives.Count, computedMetric.Objectives.Count);
-            for (var i = 0; i < _computedMetric.Objectives.Count; i++)
+            var testNumber = 4;
+
+            // Create a test workspace
+            var workspace = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+
+            // Create a test patient with a dose
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RD.dcm"), 1);
+            var entitySummary = patientItem.FindEntities(e => e.Type == "dose")[0];
+
+            // Create entity scorecards object
+            var entityScorecards = new EntityScorecards(_proKnow, workspace.Id, entitySummary.Id);
+
+            // Create computed metric
+            var computedMetric = new ComputedMetric("VOLUME_PERCENT_DOSE_RANGE_ROI", "PTV", 30, 60,
+                new List<MetricBin>() {
+                    new MetricBin("IDEAL", new byte[] { Color.Green.R, Color.Green.G, Color.Green.B }),
+                    new MetricBin("GOOD", new byte[] { Color.LightGreen.R, Color.LightGreen.G, Color.LightGreen.B }, 20),
+                    new MetricBin("ACCEPTABLE", new byte[] { Color.Yellow.R, Color.Yellow.G, Color.Yellow.B }, 40, 60),
+                    new MetricBin("MARGINAL", new byte[] { Color.Orange.R, Color.Orange.G, Color.Orange.B }, null, 80),
+                    new MetricBin("UNACCEPTABLE", new byte[] { Color.Red.R, Color.Red.G, Color.Red.B })
+                });
+
+            // Create custom metric
+            var customMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}", "dose", "number");
+
+            // Add objectives to custom metric
+            customMetricItem.Objectives = new List<MetricBin>()
             {
-                Assert.AreEqual(_computedMetric.Objectives[i].Label, computedMetric.Objectives[i].Label);
-                Assert.AreEqual(_computedMetric.Objectives[i].Color[0], computedMetric.Objectives[i].Color[0]);
-                Assert.AreEqual(_computedMetric.Objectives[i].Color[1], computedMetric.Objectives[i].Color[1]);
-                Assert.AreEqual(_computedMetric.Objectives[i].Color[2], computedMetric.Objectives[i].Color[2]);
-                Assert.AreEqual(_computedMetric.Objectives[i].Min, computedMetric.Objectives[i].Min);
-                Assert.AreEqual(_computedMetric.Objectives[i].Max, computedMetric.Objectives[i].Max);
+                new MetricBin("PASS", new byte[] { 18, 191, 0 }, null, 90),
+                new MetricBin("FAIL", new byte[] { 255, 0, 0 })
+            };
+
+            // Convert custom metric to schema expected by CreateAsync (name and objectives only)
+            var customMetric = new CustomMetric(customMetricItem.Name, customMetricItem.Objectives);
+
+            // Create entity scorecard
+            var computedMetrics = new List<ComputedMetric>() { computedMetric };
+            var customMetrics = new List<CustomMetric>() { customMetric };
+            var entityScorecardItem = await entityScorecards.CreateAsync($"{_testClassName}-{testNumber}", computedMetrics, customMetrics);
+
+            // Get the created entity scorecard
+            var createdEntityScorecardItem = await entityScorecards.GetAsync(entityScorecardItem.Id);
+            Assert.AreEqual($"{_testClassName}-{testNumber}", createdEntityScorecardItem.Name);
+            Assert.AreEqual(1, createdEntityScorecardItem.ComputedMetrics.Count);
+            var createdComputedMetric = createdEntityScorecardItem.ComputedMetrics[0];
+            Assert.AreEqual(computedMetric.Type, createdComputedMetric.Type);
+            Assert.AreEqual(computedMetric.RoiName, createdComputedMetric.RoiName);
+            Assert.AreEqual(computedMetric.Arg1, createdComputedMetric.Arg1);
+            Assert.AreEqual(computedMetric.Arg2, createdComputedMetric.Arg2);
+            Assert.AreEqual(computedMetric.Objectives.Count, createdComputedMetric.Objectives.Count);
+            for (var i = 0; i < createdComputedMetric.Objectives.Count; i++)
+            {
+                Assert.AreEqual(computedMetric.Objectives[i].Label, createdComputedMetric.Objectives[i].Label);
+                Assert.AreEqual(computedMetric.Objectives[i].Color[0], createdComputedMetric.Objectives[i].Color[0]);
+                Assert.AreEqual(computedMetric.Objectives[i].Color[1], createdComputedMetric.Objectives[i].Color[1]);
+                Assert.AreEqual(computedMetric.Objectives[i].Color[2], createdComputedMetric.Objectives[i].Color[2]);
+                Assert.AreEqual(computedMetric.Objectives[i].Min, createdComputedMetric.Objectives[i].Min);
+                Assert.AreEqual(computedMetric.Objectives[i].Max, createdComputedMetric.Objectives[i].Max);
             }
-            Assert.AreEqual(1, entityScorecardItem.CustomMetrics.Count);
-            var customMetricItem = entityScorecardItem.CustomMetrics[0];
-            Assert.AreEqual(_customMetricItem.Id, customMetricItem.Id);
-            Assert.AreEqual(_customMetricItem.Objectives.Count, customMetricItem.Objectives.Count);
-            for (var i = 0; i < _customMetricItem.Objectives.Count; i++)
+            Assert.AreEqual(1, createdEntityScorecardItem.CustomMetrics.Count);
+            var createdCustomMetricItem = createdEntityScorecardItem.CustomMetrics[0];
+            Assert.AreEqual(customMetricItem.Id, createdCustomMetricItem.Id);
+            Assert.AreEqual(customMetricItem.Objectives.Count, createdCustomMetricItem.Objectives.Count);
+            for (var i = 0; i < createdCustomMetricItem.Objectives.Count; i++)
             {
-                Assert.AreEqual(_customMetricItem.Objectives[i].Label, customMetricItem.Objectives[i].Label);
-                Assert.AreEqual(_customMetricItem.Objectives[i].Color[0], customMetricItem.Objectives[i].Color[0]);
-                Assert.AreEqual(_customMetricItem.Objectives[i].Color[1], customMetricItem.Objectives[i].Color[1]);
-                Assert.AreEqual(_customMetricItem.Objectives[i].Color[2], customMetricItem.Objectives[i].Color[2]);
-                Assert.AreEqual(_customMetricItem.Objectives[i].Min, customMetricItem.Objectives[i].Min);
-                Assert.AreEqual(_customMetricItem.Objectives[i].Max, customMetricItem.Objectives[i].Max);
+                Assert.AreEqual(customMetricItem.Objectives[i].Label, createdCustomMetricItem.Objectives[i].Label);
+                Assert.AreEqual(customMetricItem.Objectives[i].Color[0], createdCustomMetricItem.Objectives[i].Color[0]);
+                Assert.AreEqual(customMetricItem.Objectives[i].Color[1], createdCustomMetricItem.Objectives[i].Color[1]);
+                Assert.AreEqual(customMetricItem.Objectives[i].Color[2], createdCustomMetricItem.Objectives[i].Color[2]);
+                Assert.AreEqual(customMetricItem.Objectives[i].Min, createdCustomMetricItem.Objectives[i].Min);
+                Assert.AreEqual(customMetricItem.Objectives[i].Max, createdCustomMetricItem.Objectives[i].Max);
             }
         }
 
         [TestMethod]
         public async Task QueryAsyncTest()
         {
-            var entityScorecardSummaries = await _entityScorecards.QueryAsync();
-            var entityScorecardSummary = entityScorecardSummaries.First(t => t.Id == _entityScorecardItem.Id);
-            Assert.AreEqual(_entityScorecardItem.Name, entityScorecardSummary.Name);
+            var testNumber = 5;
+
+            // Create a test workspace
+            var workspace = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+
+            // Create a test patient with a dose
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RD.dcm"), 1);
+            var entitySummary = patientItem.FindEntities(e => e.Type == "dose")[0];
+
+            // Create entity scorecards object
+            var entityScorecards = new EntityScorecards(_proKnow, workspace.Id, entitySummary.Id);
+
+            // Create computed metric
+            var computedMetric = new ComputedMetric("VOLUME_PERCENT_DOSE_RANGE_ROI", "PTV", 30, 60,
+                new List<MetricBin>() {
+                    new MetricBin("IDEAL", new byte[] { Color.Green.R, Color.Green.G, Color.Green.B }),
+                    new MetricBin("GOOD", new byte[] { Color.LightGreen.R, Color.LightGreen.G, Color.LightGreen.B }, 20),
+                    new MetricBin("ACCEPTABLE", new byte[] { Color.Yellow.R, Color.Yellow.G, Color.Yellow.B }, 40, 60),
+                    new MetricBin("MARGINAL", new byte[] { Color.Orange.R, Color.Orange.G, Color.Orange.B }, null, 80),
+                    new MetricBin("UNACCEPTABLE", new byte[] { Color.Red.R, Color.Red.G, Color.Red.B })
+                });
+
+            // Create custom metric
+            var customMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}", "dose", "number");
+
+            // Add objectives to custom metric
+            customMetricItem.Objectives = new List<MetricBin>()
+            {
+                new MetricBin("PASS", new byte[] { 18, 191, 0 }, null, 90),
+                new MetricBin("FAIL", new byte[] { 255, 0, 0 })
+            };
+
+            // Convert custom metric to schema expected by CreateAsync (name and objectives only)
+            var customMetric = new CustomMetric(customMetricItem.Name, customMetricItem.Objectives);
+
+            // Create entity scorecard
+            var computedMetrics = new List<ComputedMetric>() { computedMetric };
+            var customMetrics = new List<CustomMetric>() { customMetric };
+            var entityScorecardItem = await entityScorecards.CreateAsync($"{_testClassName}-{testNumber}", computedMetrics, customMetrics);
+
+            var entityScorecardSummaries = await entityScorecards.QueryAsync();
+            var entityScorecardSummary = entityScorecardSummaries.First(t => t.Id == entityScorecardItem.Id);
+            Assert.AreEqual(entityScorecardItem.Name, entityScorecardSummary.Name);
         }
     }
 }

--- a/proknow-sdk-test/PatientTest/EntitiesTest/ImageSetItemTest.cs
+++ b/proknow-sdk-test/PatientTest/EntitiesTest/ImageSetItemTest.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ProKnow.Test;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -18,14 +17,8 @@ namespace ProKnow.Patient.Entities.Test
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete download directory, if necessary
-            if (Directory.Exists(_downloadFolder))
-            {
-                Directory.Delete(_downloadFolder, true);
-            }
-
-            // Delete test workspaces, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_testClassName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
         }
 
         [ClassCleanup]

--- a/proknow-sdk-test/PatientTest/EntitiesTest/ImageSetItemTest.cs
+++ b/proknow-sdk-test/PatientTest/EntitiesTest/ImageSetItemTest.cs
@@ -9,7 +9,6 @@ namespace ProKnow.Patient.Entities.Test
     public class ImageSetItemTest
     {
         private static readonly string _testClassName = nameof(ImageSetItemTest);
-        private static readonly ProKnowApi _proKnow = TestSettings.ProKnow;
         private static readonly string _downloadFolder = Path.Combine(Path.GetTempPath(), _testClassName);
 
         [ClassInitialize]
@@ -40,7 +39,7 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 1;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an imageset
             var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "CT"), 1);
@@ -66,7 +65,7 @@ namespace ProKnow.Patient.Entities.Test
             int testNumber = 2;
 
             // Create a workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a patient with an image set
             var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "CT"), 1);

--- a/proknow-sdk-test/PatientTest/EntitiesTest/PlanItemTest.cs
+++ b/proknow-sdk-test/PatientTest/EntitiesTest/PlanItemTest.cs
@@ -8,22 +8,18 @@ namespace ProKnow.Patient.Entities.Test
     [TestClass]
     public class PlanItemTest
     {
-        private static readonly string _patientMrnAndName = "SDK-PlanItemTest";
-        private static readonly string _downloadFolderRoot = Path.Combine(Path.GetTempPath(), _patientMrnAndName);
+        private static readonly string _testClassName = nameof(PlanItemTest);
+        private static readonly string _downloadFolderRoot = Path.Combine(Path.GetTempPath(), _testClassName);
 
         [ClassInitialize]
 #pragma warning disable IDE0060 // Remove unused parameter
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test workspaces, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
 
             // Create download folder root
-            if (Directory.Exists(_downloadFolderRoot))
-            {
-                Directory.Delete(_downloadFolderRoot, true);
-            }
             Directory.CreateDirectory(_downloadFolderRoot);
         }
 
@@ -31,7 +27,7 @@ namespace ProKnow.Patient.Entities.Test
         public static async Task ClassCleanup()
         {
             // Delete test workspaces
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            await TestHelper.DeleteWorkspacesAsync(_testClassName);
 
             // Delete download folder
             if (Directory.Exists(_downloadFolderRoot))
@@ -46,11 +42,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 1;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
-            var workspaceId = workspaceItem.Id;
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "RP.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RP.dcm"), 1);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "plan");
             var planItem = await entitySummaries[0].GetAsync() as PlanItem;
 
@@ -74,11 +69,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 2;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
-            var workspaceId = workspaceItem.Id;
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "RP.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RP.dcm"), 1);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "plan");
             var planItem = await entitySummaries[0].GetAsync() as PlanItem;
 
@@ -103,11 +97,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 3;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
-            var workspaceId = workspaceItem.Id;
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "RP.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RP.dcm"), 1);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "plan");
             var planItem = await entitySummaries[0].GetAsync() as PlanItem;
 
@@ -130,11 +123,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 4;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
-            var workspaceId = workspaceItem.Id;
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "RP.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RP.dcm"), 1);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "plan");
             var planItem = await entitySummaries[0].GetAsync() as PlanItem;
 

--- a/proknow-sdk-test/PatientTest/EntitiesTest/StructureSetItemTest.cs
+++ b/proknow-sdk-test/PatientTest/EntitiesTest/StructureSetItemTest.cs
@@ -13,24 +13,20 @@ namespace ProKnow.Patient.Entities.Test
     [TestClass]
     public class StructureSetItemTest
     {
-        private static readonly string _patientMrnAndName = "SDK-StructureSetItemTest";
+        private static readonly string _testClassName = nameof(StructureSetItemTest);
         private static readonly ProKnowApi _proKnow = TestSettings.ProKnow;
         private static readonly int _lockRenewalBuffer = _proKnow.LockRenewalBuffer;
-        private static readonly string _downloadFolderRoot = Path.Combine(Path.GetTempPath(), _patientMrnAndName);
+        private static readonly string _downloadFolderRoot = Path.Combine(Path.GetTempPath(), _testClassName);
 
         [ClassInitialize]
 #pragma warning disable IDE0060 // Remove unused parameter
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test workspace, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
 
             // Create download folder root
-            if (Directory.Exists(_downloadFolderRoot))
-            {
-                Directory.Delete(_downloadFolderRoot, true);
-            }
             Directory.CreateDirectory(_downloadFolderRoot);
         }
 
@@ -38,7 +34,7 @@ namespace ProKnow.Patient.Entities.Test
         public static async Task ClassCleanup()
         {
             // Delete test workspaces
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            await TestHelper.DeleteWorkspacesAsync(_testClassName);
 
             // Delete download folder
             if (Directory.Exists(_downloadFolderRoot))
@@ -56,10 +52,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 1;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -81,10 +77,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 2;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
             var originalRoiCount = structureSetItem.Rois.Length;
@@ -117,7 +113,7 @@ namespace ProKnow.Patient.Entities.Test
                 // Verify the returned structure set item
                 Assert.AreEqual(workspaceItem.Id, approvedStructureSetItem.WorkspaceId);
                 Assert.AreEqual(originalRoiCount + 1, approvedStructureSetItem.Rois.Length);
-                Assert.IsTrue(approvedStructureSetItem.Rois.Where(r => r.Name == "thing1").Any());
+                Assert.IsTrue(approvedStructureSetItem.Rois.Any(r => r.Name == "thing1"));
             }
         }
 
@@ -127,11 +123,11 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 3;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
 
             // Create a test patient with only an image set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "CT"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "CT"), 1);
 
             // Create a new structure set
             var imageSetSummary = patientItem.FindEntities(e => e.Type == "image_set")[0];
@@ -156,10 +152,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 4;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with only an image set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "CT"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "CT"), 1);
 
             // Create a new structure set
             var imageSetSummary = patientItem.FindEntities(e => e.Type == "image_set")[0];
@@ -200,10 +196,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 5;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -225,10 +221,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 6;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -261,10 +257,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 7;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -292,10 +288,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 8;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -319,10 +315,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 9;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -347,10 +343,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 10;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -373,10 +369,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 11;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -399,10 +395,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 12;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with a structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -448,10 +444,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 13;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with a structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -491,10 +487,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 14;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -522,10 +518,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 15;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
             var originalRoiCount = structureSetItem.Rois.Length;
@@ -537,14 +533,14 @@ namespace ProKnow.Patient.Entities.Test
             {
                 // Add an ROI and commit (approve) the change
                 await draft.CreateRoiAsync("thing1", Color.Magenta, "ORGAN");
-                var approvedStructureSetItem = await draft.ApproveAsync("original + thing1");
+                await draft.ApproveAsync("original + thing1");
 
                 // Refresh the original structure set item
                 await structureSetItem.RefreshAsync();
 
                 // Verify the refreshed structure set item
                 Assert.AreEqual(originalRoiCount + 1, structureSetItem.Rois.Length);
-                Assert.IsTrue(structureSetItem.Rois.Where(r => r.Name == "thing1").Any());
+                Assert.IsTrue(structureSetItem.Rois.Any(r => r.Name == "thing1"));
             }
         }
 
@@ -554,10 +550,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 16;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -571,10 +567,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 17;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -607,10 +603,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 18;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -624,10 +620,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 19;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -676,10 +672,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 20;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -693,10 +689,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 21;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -727,10 +723,10 @@ namespace ProKnow.Patient.Entities.Test
             var testNumber = 22;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with a structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 

--- a/proknow-sdk-test/PatientTest/EntitiesTest/StructureSetTest/StructureSetRoiItemTest.cs
+++ b/proknow-sdk-test/PatientTest/EntitiesTest/StructureSetTest/StructureSetRoiItemTest.cs
@@ -10,22 +10,22 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
     [TestClass]
     public class StructureSetRoiItemTest
     {
-        private static readonly string _patientMrnAndName = "SDK-StructureSetRoiItemTest";
+        private static readonly string _testClassName = nameof(StructureSetRoiItemTest);
 
         [ClassInitialize]
 #pragma warning disable IDE0060 // Remove unused parameter
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test workspaces, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
         }
 
         [ClassCleanup]
         public static async Task ClassCleanup()
         {
             // Delete test workspaces
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            await TestHelper.DeleteWorkspacesAsync(_testClassName);
         }
 
         [TestMethod]
@@ -34,10 +34,10 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             var testNumber = 1;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with a structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -58,7 +58,7 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             await structureSetItem.RefreshAsync();
 
             // Verify that the PTV was deleted
-            Assert.IsFalse(structureSetItem.Rois.Where(r => r.Name == "PTV").Any());
+            Assert.IsFalse(structureSetItem.Rois.Any(r => r.Name == "PTV"));
         }
 
         [TestMethod]
@@ -67,10 +67,10 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             var testNumber = 2;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with a structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -99,10 +99,10 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             var testNumber = 3;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with a structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -129,7 +129,7 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             await structureSetItem.RefreshAsync();
 
             // Verify that changes to the PTV were saved
-            Assert.IsFalse(structureSetItem.Rois.Where(r => r.Name == "PTV").Any());
+            Assert.IsFalse(structureSetItem.Rois.Any(r => r.Name == "PTV"));
             var roiItem2 = structureSetItem.Rois.First(r => r.Name == "PTV2");
             Assert.AreEqual(roiItem0.Tag, roiItem2.Tag);
             Assert.AreEqual(Color.Blue.ToArgb(), roiItem2.Color.ToArgb());

--- a/proknow-sdk-test/PatientTest/EntitiesTest/StructureSetTest/StructureSetVersionItemTest.cs
+++ b/proknow-sdk-test/PatientTest/EntitiesTest/StructureSetTest/StructureSetVersionItemTest.cs
@@ -12,23 +12,19 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
     [TestClass]
     public class StructureSetVersionItemTest
     {
-        private static readonly string _patientMrnAndName = "SDK-StructureSetVersionItemTest";
+        private static readonly string _testClassName = nameof(StructureSetVersionItemTest);
         private static readonly ProKnowApi _proKnow = TestSettings.ProKnow;
-        private static readonly string _downloadFolderRoot = Path.Combine(Path.GetTempPath(), _patientMrnAndName);
+        private static readonly string _downloadFolderRoot = Path.Combine(Path.GetTempPath(), _testClassName);
 
         [ClassInitialize]
 #pragma warning disable IDE0060 // Remove unused parameter
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test workspace, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
 
             // Create download folder root
-            if (Directory.Exists(_downloadFolderRoot))
-            {
-                Directory.Delete(_downloadFolderRoot, true);
-            }
             Directory.CreateDirectory(_downloadFolderRoot);
         }
 
@@ -36,7 +32,7 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
         public static async Task ClassCleanup()
         {
             // Delete test workspaces
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            await TestHelper.DeleteWorkspacesAsync(_testClassName);
 
             // Delete download folder
             if (Directory.Exists(_downloadFolderRoot))
@@ -51,10 +47,10 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             var testNumber = 1;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -86,10 +82,10 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             var testNumber = 2;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -126,8 +122,8 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             // Verify the version was deleted
             versions = await structureSetItem.Versions.QueryAsync();
             Assert.AreEqual(2, versions.Count);
-            Assert.IsTrue(versions.Where(v => v.Label == "original").Any());
-            Assert.IsTrue(versions.Where(v => v.Label == "original + thing1 + thing2").Any());
+            Assert.IsTrue(versions.Any(v => v.Label == "original"));
+            Assert.IsTrue(versions.Any(v => v.Label == "original + thing1 + thing2"));
         }
 
         [TestMethod]
@@ -136,10 +132,10 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             var testNumber = 3;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -171,10 +167,10 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             var testNumber = 4;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -222,7 +218,7 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             }
 
             // Verify that the version downloaded (and uploaded to a new patient) was correct
-            Assert.IsTrue(structureSetItem2.Rois.Where(r => r.Name == "thing1").Any());
+            Assert.IsTrue(structureSetItem2.Rois.Any(r => r.Name == "thing1"));
         }
 
         [TestMethod]
@@ -231,10 +227,10 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             var testNumber = 5;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -283,7 +279,7 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             }
 
             // Verify that the version downloaded (and uploaded to a new patient) was correct
-            Assert.IsTrue(structureSetItem2.Rois.Where(r => r.Name == "thing1").Any());
+            Assert.IsTrue(structureSetItem2.Rois.Any(r => r.Name == "thing1"));
         }
 
         [TestMethod]
@@ -292,10 +288,10 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             var testNumber = 6;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -342,7 +338,7 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             }
 
             // Verify that the version downloaded (and uploaded to a new patient) was correct
-            Assert.IsTrue(structureSetItem2.Rois.Where(r => r.Name == "thing1").Any());
+            Assert.IsTrue(structureSetItem2.Rois.Any(r => r.Name == "thing1"));
         }
 
         [TestMethod]
@@ -351,10 +347,10 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             var testNumber = 7;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -401,7 +397,7 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             }
 
             // Verify that the version downloaded (and uploaded to a new patient) was correct
-            Assert.IsTrue(structureSetItem2.Rois.Where(r => r.Name == "thing1").Any());
+            Assert.IsTrue(structureSetItem2.Rois.Any(r => r.Name == "thing1"));
         }
 
         [TestMethod]
@@ -410,10 +406,10 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             var testNumber = 8;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -442,10 +438,10 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             var testNumber = 9;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -486,13 +482,13 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
                 else if (version.Label == "original + thing1")
                 {
                     Assert.AreEqual(originalRoiCount + 1, versionStructureSetItem.Rois.Length);
-                    Assert.IsTrue(versionStructureSetItem.Rois.Where(r => r.Name == "thing1").Any());
+                    Assert.IsTrue(versionStructureSetItem.Rois.Any(r => r.Name == "thing1"));
                 }
                 else if (version.Label == "original + thing1 + thing2")
                 {
                     Assert.AreEqual(originalRoiCount + 2, versionStructureSetItem.Rois.Length);
-                    Assert.IsTrue(versionStructureSetItem.Rois.Where(r => r.Name == "thing1").Any());
-                    Assert.IsTrue(versionStructureSetItem.Rois.Where(r => r.Name == "thing2").Any());
+                    Assert.IsTrue(versionStructureSetItem.Rois.Any(r => r.Name == "thing1"));
+                    Assert.IsTrue(versionStructureSetItem.Rois.Any(r => r.Name == "thing2"));
                 }
                 else
                 {
@@ -507,10 +503,10 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             var testNumber = 10;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -542,10 +538,10 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             var testNumber = 11;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
             var originalRoiCount = structureSetItem.Rois.Length;
@@ -575,12 +571,12 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
 
             // Verify the returned structure set item
             Assert.AreEqual(originalRoiCount + 1, revertedStructureSetItem.Rois.Length);
-            Assert.IsTrue(revertedStructureSetItem.Rois.Where(r => r.Name == "thing1").Any());
+            Assert.IsTrue(revertedStructureSetItem.Rois.Any(r => r.Name == "thing1"));
 
             // Verify the structure set was reverted to the second version
             await structureSetItem.RefreshAsync();
             Assert.AreEqual(originalRoiCount + 1, structureSetItem.Rois.Length);
-            Assert.IsTrue(structureSetItem.Rois.Where(r => r.Name == "thing1").Any());
+            Assert.IsTrue(structureSetItem.Rois.Any(r => r.Name == "thing1"));
         }
 
         [TestMethod]
@@ -589,10 +585,10 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             var testNumber = 12;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -615,4 +611,3 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
         }
     }
 }
-

--- a/proknow-sdk-test/PatientTest/EntitiesTest/StructureSetTest/StructureSetVersionItemTest.cs
+++ b/proknow-sdk-test/PatientTest/EntitiesTest/StructureSetTest/StructureSetVersionItemTest.cs
@@ -199,23 +199,13 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             {
                 Patient = new PatientCreateSchema { Mrn = $"{patientItem.Mrn}2", Name = $"{patientItem.Name}2" }
             };
-            await _proKnow.Uploads.UploadAsync(workspaceItem.Id, actualDownloadPath, overrides, true);
-            StructureSetItem structureSetItem2;
-            while (true)
-            {
-                var patientSummaries = await _proKnow.Patients.LookupAsync(workspaceItem.Id, new string[] { $"{patientItem.Mrn}2" });
-                if (patientSummaries[0] != null)
-                {
-                    var patientSummary2 = patientSummaries[0];
-                    var patientItem2 = await patientSummary2.GetAsync();
-                    var entitySummary2 = patientItem2.FindEntities(e => true)[0];
-                    if (entitySummary2.Status == "completed")
-                    {
-                        structureSetItem2 = (await entitySummary2.GetAsync()) as StructureSetItem;
-                        break;
-                    }
-                }
-            }
+            await _proKnow.Uploads.UploadAsync(workspaceItem.Id, actualDownloadPath, overrides);
+
+            // Get the uploaded structure set
+            var patientSummary2 = await _proKnow.Patients.FindAsync(workspaceItem.Id, p => p.Mrn == $"{patientItem.Mrn}2");
+            var patientItem2 = await patientSummary2.GetAsync();
+            var entitySummary2 = patientItem2.FindEntities(e => true)[0];
+            var structureSetItem2 = (await entitySummary2.GetAsync()) as StructureSetItem;
 
             // Verify that the version downloaded (and uploaded to a new patient) was correct
             Assert.IsTrue(structureSetItem2.Rois.Any(r => r.Name == "thing1"));
@@ -260,23 +250,13 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             {
                 Patient = new PatientCreateSchema { Mrn = $"{patientItem.Mrn}2", Name = $"{patientItem.Name}2" }
             };
-            await _proKnow.Uploads.UploadAsync(workspaceItem.Id, actualDownloadPath, overrides, true);
-            StructureSetItem structureSetItem2;
-            while (true)
-            {
-                var patientSummaries = await _proKnow.Patients.LookupAsync(workspaceItem.Id, new string[] { $"{patientItem.Mrn}2" });
-                if (patientSummaries[0] != null)
-                {
-                    var patientSummary2 = patientSummaries[0];
-                    var patientItem2 = await patientSummary2.GetAsync();
-                    var entitySummary2 = patientItem2.FindEntities(e => true)[0];
-                    if (entitySummary2.Status == "completed")
-                    {
-                        structureSetItem2 = (await entitySummary2.GetAsync()) as StructureSetItem;
-                        break;
-                    }
-                }
-            }
+            await _proKnow.Uploads.UploadAsync(workspaceItem.Id, actualDownloadPath, overrides);
+
+            // Get the uploaded structure set
+            var patientSummary2 = await _proKnow.Patients.FindAsync(workspaceItem.Id, p => p.Mrn == $"{patientItem.Mrn}2");
+            var patientItem2 = await patientSummary2.GetAsync();
+            var entitySummary2 = patientItem2.FindEntities(e => true)[0];
+            var structureSetItem2 = (await entitySummary2.GetAsync()) as StructureSetItem;
 
             // Verify that the version downloaded (and uploaded to a new patient) was correct
             Assert.IsTrue(structureSetItem2.Rois.Any(r => r.Name == "thing1"));
@@ -319,23 +299,13 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             {
                 Patient = new PatientCreateSchema { Mrn = $"{patientItem.Mrn}2", Name = $"{patientItem.Name}2" }
             };
-            await _proKnow.Uploads.UploadAsync(workspaceItem.Id, actualDownloadPath, overrides, true);
-            StructureSetItem structureSetItem2;
-            while (true)
-            {
-                var patientSummaries = await _proKnow.Patients.LookupAsync(workspaceItem.Id, new string[] { $"{patientItem.Mrn}2" });
-                if (patientSummaries[0] != null)
-                {
-                    var patientSummary2 = patientSummaries[0];
-                    var patientItem2 = await patientSummary2.GetAsync();
-                    var entitySummary2 = patientItem2.FindEntities(e => true)[0];
-                    if (entitySummary2.Status == "completed")
-                    {
-                        structureSetItem2 = (await entitySummary2.GetAsync()) as StructureSetItem;
-                        break;
-                    }
-                }
-            }
+            await _proKnow.Uploads.UploadAsync(workspaceItem.Id, actualDownloadPath, overrides);
+
+            // Get the uploaded structure set
+            var patientSummary2 = await _proKnow.Patients.FindAsync(workspaceItem.Id, p => p.Mrn == $"{patientItem.Mrn}2");
+            var patientItem2 = await patientSummary2.GetAsync();
+            var entitySummary2 = patientItem2.FindEntities(e => true)[0];
+            var structureSetItem2 = (await entitySummary2.GetAsync()) as StructureSetItem;
 
             // Verify that the version downloaded (and uploaded to a new patient) was correct
             Assert.IsTrue(structureSetItem2.Rois.Any(r => r.Name == "thing1"));
@@ -378,23 +348,13 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             {
                 Patient = new PatientCreateSchema { Mrn = $"{patientItem.Mrn}2", Name = $"{patientItem.Name}2" }
             };
-            await _proKnow.Uploads.UploadAsync(workspaceItem.Id, actualDownloadPath, overrides, true);
-            StructureSetItem structureSetItem2;
-            while (true)
-            {
-                var patientSummaries = await _proKnow.Patients.LookupAsync(workspaceItem.Id, new string[] { $"{patientItem.Mrn}2" });
-                if (patientSummaries[0] != null)
-                {
-                    var patientSummary2 = patientSummaries[0];
-                    var patientItem2 = await patientSummary2.GetAsync();
-                    var entitySummary2 = patientItem2.FindEntities(e => true)[0];
-                    if (entitySummary2.Status == "completed")
-                    {
-                        structureSetItem2 = (await entitySummary2.GetAsync()) as StructureSetItem;
-                        break;
-                    }
-                }
-            }
+            await _proKnow.Uploads.UploadAsync(workspaceItem.Id, actualDownloadPath, overrides);
+
+            // Get the uploaded structure set
+            var patientSummary2 = await _proKnow.Patients.FindAsync(workspaceItem.Id, p => p.Mrn == $"{patientItem.Mrn}2");
+            var patientItem2 = await patientSummary2.GetAsync();
+            var entitySummary2 = patientItem2.FindEntities(e => true)[0];
+            var structureSetItem2 = (await entitySummary2.GetAsync()) as StructureSetItem;
 
             // Verify that the version downloaded (and uploaded to a new patient) was correct
             Assert.IsTrue(structureSetItem2.Rois.Any(r => r.Name == "thing1"));

--- a/proknow-sdk-test/PatientTest/EntitiesTest/StructureSetTest/StructureSetVersionsTest.cs
+++ b/proknow-sdk-test/PatientTest/EntitiesTest/StructureSetTest/StructureSetVersionsTest.cs
@@ -10,22 +10,22 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
     [TestClass]
     public class StructureSetVersionsTest
     {
-        private static readonly string _patientMrnAndName = "SDK-StructureSetVersionsTest";
+        private static readonly string _testClassName = nameof(StructureSetVersionsTest);
 
         [ClassInitialize]
 #pragma warning disable IDE0060 // Remove unused parameter
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test workspace, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
         }
 
         [ClassCleanup]
         public static async Task ClassCleanup()
         {
             // Delete test workspaces
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            await TestHelper.DeleteWorkspacesAsync(_testClassName);
         }
 
         [TestMethod]
@@ -34,10 +34,10 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             var testNumber = 1;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with an image set and structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Becker^Matthew", 4);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -74,8 +74,8 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             // Verify the version was deleted
             versions = await structureSetItem.Versions.QueryAsync();
             Assert.AreEqual(2, versions.Count);
-            Assert.IsTrue(versions.Where(v => v.Label == "original").Any());
-            Assert.IsTrue(versions.Where(v => v.Label == "original + thing1 + thing2").Any());
+            Assert.IsTrue(versions.Any(v => v.Label == "original"));
+            Assert.IsTrue(versions.Any(v => v.Label == "original + thing1 + thing2"));
         }
 
         [TestMethod]
@@ -84,10 +84,10 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             var testNumber = 2;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with a structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem1 = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -112,10 +112,10 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             var testNumber = 3;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient with a structure set
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RS.dcm"), 1);
             var entitySummaries = patientItem.FindEntities(e => e.Type == "structure_set");
             var structureSetItem = await entitySummaries[0].GetAsync() as StructureSetItem;
 
@@ -138,9 +138,9 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             // Query the versions and verify the results
             var structureSetVersionItems = await structureSetItem.Versions.QueryAsync();
             Assert.AreEqual(3, structureSetVersionItems.Count);
-            Assert.IsTrue(structureSetVersionItems.Where(v => v.Label == null).Any());
-            Assert.IsTrue(structureSetVersionItems.Where(v => v.Label == "original + thing1").Any());
-            Assert.IsTrue(structureSetVersionItems.Where(v => v.Label == "original + thing1 + thing2").Any());
+            Assert.IsTrue(structureSetVersionItems.Any(v => v.Label == null));
+            Assert.IsTrue(structureSetVersionItems.Any(v => v.Label == "original + thing1"));
+            Assert.IsTrue(structureSetVersionItems.Any(v => v.Label == "original + thing1 + thing2"));
         }
     }
 }

--- a/proknow-sdk-test/PatientTest/PatientItemTest.cs
+++ b/proknow-sdk-test/PatientTest/PatientItemTest.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ProKnow.Patient.Entities;
-using ProKnow.Scorecard;
 using ProKnow.Test;
 using ProKnow.Upload;
 using System.Collections.Generic;
@@ -15,27 +14,14 @@ namespace ProKnow.Patient.Test
     {
         private static readonly string _testClassName = nameof(PatientItemTest);
         private static readonly ProKnowApi _proKnow = TestSettings.ProKnow;
-        private static readonly Uploads _uploads = _proKnow.Uploads;
-        private static CustomMetricItem _enumCustomMetricItem;
-        private static CustomMetricItem _numberCustomMetricItem;
-        private static CustomMetricItem _stringCustomMetricItem;
 
         [ClassInitialize]
 #pragma warning disable IDE0060 // Remove unused parameter
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete existing custom metrics, if necessary
-            await TestHelper.DeleteCustomMetricsAsync(_testClassName);
-
-            // Create custom metrics for testing
-            _enumCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-enum", "patient", "enum",
-                new string[] { "one", "two", "three" });
-            _numberCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-number", "patient", "number");
-            _stringCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-string", "patient", "string");
-
-            // Delete test workspaces, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_testClassName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
         }
 
         [ClassCleanup]
@@ -54,7 +40,7 @@ namespace ProKnow.Patient.Test
             int testNumber = 1;
 
             // Create a workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a patient with only images
             var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "CT"), 1);
@@ -96,7 +82,7 @@ namespace ProKnow.Patient.Test
             int testNumber = 3;
 
             // Create a workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a patient
             var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Becker^Matthew", 4);
@@ -114,7 +100,7 @@ namespace ProKnow.Patient.Test
             int testNumber = 4;
 
             // Create a workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a patient
             var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Sro", 3);
@@ -128,15 +114,21 @@ namespace ProKnow.Patient.Test
         {
             int testNumber = 5;
 
+            // Create custom metrics
+            var enumCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-enum", "patient", "enum",
+                new string[] { "one", "two", "three" });
+            var numberCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-number", "patient", "number");
+            var stringCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-string", "patient", "string");
+
             // Create a workspace
             await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a patient with metadata
             var metadata = new Dictionary<string, object>
             {
-                { _enumCustomMetricItem.Name, "one" },
-                { _numberCustomMetricItem.Name, 1 },
-                { _stringCustomMetricItem.Name, "I" }
+                { enumCustomMetricItem.Name, "one" },
+                { numberCustomMetricItem.Name, 1 },
+                { stringCustomMetricItem.Name, "I" }
             };
             var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, null, 0, null, null, metadata);
 
@@ -145,12 +137,12 @@ namespace ProKnow.Patient.Test
 
             // Verify the resolved metadata
             Assert.AreEqual(3, resolvedMetadata.Keys.Count);
-            Assert.IsTrue(resolvedMetadata.ContainsKey(_enumCustomMetricItem.Name));
-            Assert.AreEqual("one", resolvedMetadata[_enumCustomMetricItem.Name]);
-            Assert.IsTrue(resolvedMetadata.ContainsKey(_numberCustomMetricItem.Name));
-            Assert.AreEqual(1, resolvedMetadata[_numberCustomMetricItem.Name]);
-            Assert.IsTrue(resolvedMetadata.ContainsKey(_stringCustomMetricItem.Name));
-            Assert.AreEqual("I", resolvedMetadata[_stringCustomMetricItem.Name]);
+            Assert.IsTrue(resolvedMetadata.ContainsKey(enumCustomMetricItem.Name));
+            Assert.AreEqual("one", resolvedMetadata[enumCustomMetricItem.Name]);
+            Assert.IsTrue(resolvedMetadata.ContainsKey(numberCustomMetricItem.Name));
+            Assert.AreEqual(1, resolvedMetadata[numberCustomMetricItem.Name]);
+            Assert.IsTrue(resolvedMetadata.ContainsKey(stringCustomMetricItem.Name));
+            Assert.AreEqual("I", resolvedMetadata[stringCustomMetricItem.Name]);
         }
 
         [TestMethod]
@@ -184,6 +176,12 @@ namespace ProKnow.Patient.Test
         {
             int testNumber = 7;
 
+            // Create custom metrics
+            var enumCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-enum", "patient", "enum",
+                new string[] { "one", "two", "three" });
+            var numberCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-number", "patient", "number");
+            var stringCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-string", "patient", "string");
+
             // Create a workspace
             var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
@@ -198,9 +196,9 @@ namespace ProKnow.Patient.Test
             patientItem.Sex = "M";
             var metadata = new Dictionary<string, object>
             {
-                { _enumCustomMetricItem.Name, "one" },
-                { _numberCustomMetricItem.Name, 1 },
-                { _stringCustomMetricItem.Name, "I" }
+                { enumCustomMetricItem.Name, "one" },
+                { numberCustomMetricItem.Name, 1 },
+                { stringCustomMetricItem.Name, "I" }
             };
             await patientItem.SetMetadataAsync(metadata);
 
@@ -215,18 +213,24 @@ namespace ProKnow.Patient.Test
             Assert.AreEqual("1776-07-04", patientItem2.BirthDate);
             Assert.AreEqual("M", patientItem2.Sex);
             Assert.AreEqual(3, patientItem2.Metadata.Keys.Count);
-            Assert.IsTrue(patientItem2.Metadata.ContainsKey(_enumCustomMetricItem.Id));
-            Assert.AreEqual("one", patientItem2.Metadata[_enumCustomMetricItem.Id]);
-            Assert.IsTrue(patientItem2.Metadata.ContainsKey(_numberCustomMetricItem.Id));
-            Assert.AreEqual(1, patientItem2.Metadata[_numberCustomMetricItem.Id]);
-            Assert.IsTrue(patientItem2.Metadata.ContainsKey(_stringCustomMetricItem.Id));
-            Assert.AreEqual("I", patientItem2.Metadata[_stringCustomMetricItem.Id]);
+            Assert.IsTrue(patientItem2.Metadata.ContainsKey(enumCustomMetricItem.Id));
+            Assert.AreEqual("one", patientItem2.Metadata[enumCustomMetricItem.Id]);
+            Assert.IsTrue(patientItem2.Metadata.ContainsKey(numberCustomMetricItem.Id));
+            Assert.AreEqual(1, patientItem2.Metadata[numberCustomMetricItem.Id]);
+            Assert.IsTrue(patientItem2.Metadata.ContainsKey(stringCustomMetricItem.Id));
+            Assert.AreEqual("I", patientItem2.Metadata[stringCustomMetricItem.Id]);
         }
 
         [TestMethod]
         public async Task SetMetadataAsyncTest()
         {
             int testNumber = 8;
+
+            // Create custom metrics
+            var enumCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-enum", "patient", "enum",
+                new string[] { "one", "two", "three" });
+            var numberCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-number", "patient", "number");
+            var stringCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-string", "patient", "string");
 
             // Create a workspace
             await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
@@ -238,20 +242,20 @@ namespace ProKnow.Patient.Test
             // Set the metadata
             var metadata = new Dictionary<string, object>
             {
-                { _enumCustomMetricItem.Name, "one" },
-                { _numberCustomMetricItem.Name, 1 },
-                { _stringCustomMetricItem.Name, "I" }
+                { enumCustomMetricItem.Name, "one" },
+                { numberCustomMetricItem.Name, 1 },
+                { stringCustomMetricItem.Name, "I" }
             };
             await patientItem.SetMetadataAsync(metadata);
 
             // Verify the metadata property was set using resolved ProKnow IDs
             Assert.AreEqual(3, patientItem.Metadata.Keys.Count);
-            Assert.IsTrue(patientItem.Metadata.ContainsKey(_enumCustomMetricItem.Id));
-            Assert.AreEqual("one", patientItem.Metadata[_enumCustomMetricItem.Id]);
-            Assert.IsTrue(patientItem.Metadata.ContainsKey(_numberCustomMetricItem.Id));
-            Assert.AreEqual(1, patientItem.Metadata[_numberCustomMetricItem.Id]);
-            Assert.IsTrue(patientItem.Metadata.ContainsKey(_stringCustomMetricItem.Id));
-            Assert.AreEqual("I", patientItem.Metadata[_stringCustomMetricItem.Id]);
+            Assert.IsTrue(patientItem.Metadata.ContainsKey(enumCustomMetricItem.Id));
+            Assert.AreEqual("one", patientItem.Metadata[enumCustomMetricItem.Id]);
+            Assert.IsTrue(patientItem.Metadata.ContainsKey(numberCustomMetricItem.Id));
+            Assert.AreEqual(1, patientItem.Metadata[numberCustomMetricItem.Id]);
+            Assert.IsTrue(patientItem.Metadata.ContainsKey(stringCustomMetricItem.Id));
+            Assert.AreEqual("I", patientItem.Metadata[stringCustomMetricItem.Id]);
         }
 
         [TestMethod]
@@ -260,7 +264,7 @@ namespace ProKnow.Patient.Test
             int testNumber = 9;
 
             // Create a workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a patient without data
             var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber);
@@ -271,7 +275,7 @@ namespace ProKnow.Patient.Test
             {
                 Patient = new PatientCreateSchema { Mrn = patientItem.Mrn, Name = patientItem.Name }
             };
-            var uploadBatch = await patientItem.UploadAsync(uploadPath, overrides);
+            await patientItem.UploadAsync(uploadPath, overrides);
 
             // Verify test file was uploaded (may have to wait for file to be processed)
             while (true)
@@ -291,7 +295,7 @@ namespace ProKnow.Patient.Test
             int testNumber = 10;
 
             // Create a workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a patient without data
             var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber);
@@ -302,8 +306,7 @@ namespace ProKnow.Patient.Test
             {
                 Patient = new PatientCreateSchema { Mrn = patientItem.Mrn, Name = patientItem.Name }
             };
-            var uploadBatch = await patientItem.UploadAsync(uploadPath, overrides);
-            var uploadedFiles = Directory.GetFiles(uploadPath);
+            await patientItem.UploadAsync(uploadPath, overrides);
 
             // Verify test folder was uploaded (may have to wait for files to be processed)
             while (true)
@@ -327,7 +330,7 @@ namespace ProKnow.Patient.Test
             int testNumber = 11;
 
             // Create a workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a patient without data
             var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber);
@@ -340,7 +343,7 @@ namespace ProKnow.Patient.Test
             {
                 Patient = new PatientCreateSchema { Mrn = patientItem.Mrn, Name = patientItem.Name }
             };
-            var uploadBatch = await patientItem.UploadAsync(uploadPaths, overrides);
+            await patientItem.UploadAsync(uploadPaths, overrides);
 
             // Verify test folder and test file were uploaded (may have to wait for files to be processed)
             while (true)

--- a/proknow-sdk-test/PatientTest/PatientItemTest.cs
+++ b/proknow-sdk-test/PatientTest/PatientItemTest.cs
@@ -277,16 +277,10 @@ namespace ProKnow.Patient.Test
             };
             await patientItem.UploadAsync(uploadPath, overrides);
 
-            // Verify test file was uploaded (may have to wait for file to be processed)
-            while (true)
-            {
-                await patientItem.RefreshAsync();
-                var entitySummaries = patientItem.FindEntities(t => true);
-                if (entitySummaries.Count == 1)
-                {
-                    break;
-                }
-            }
+            // Verify test file was uploaded
+            await patientItem.RefreshAsync();
+            var entitySummaries = patientItem.FindEntities(t => true);
+            Assert.AreEqual(1, entitySummaries.Count);
         }
 
         [TestMethod]
@@ -308,20 +302,12 @@ namespace ProKnow.Patient.Test
             };
             await patientItem.UploadAsync(uploadPath, overrides);
 
-            // Verify test folder was uploaded (may have to wait for files to be processed)
-            while (true)
-            {
-                await patientItem.RefreshAsync();
-                var entitySummaries = patientItem.FindEntities(t => true);
-                if (entitySummaries.Count == 1 && entitySummaries[0].Status == "completed")
-                {
-                    var entityItem = await entitySummaries[0].GetAsync() as ImageSetItem;
-                    if (entityItem.Data.Images.Count == 5)
-                    {
-                        break;
-                    }
-                }
-            }
+            // Verify test folder was uploaded
+            await patientItem.RefreshAsync();
+            var entitySummaries = patientItem.FindEntities(t => true);
+            Assert.AreEqual(1, entitySummaries.Count);
+            var entityItem = await entitySummaries[0].GetAsync() as ImageSetItem;
+            Assert.AreEqual(5, entityItem.Data.Images.Count);
         }
 
         [TestMethod]
@@ -345,21 +331,14 @@ namespace ProKnow.Patient.Test
             };
             await patientItem.UploadAsync(uploadPaths, overrides);
 
-            // Verify test folder and test file were uploaded (may have to wait for files to be processed)
-            while (true)
-            {
-                await patientItem.RefreshAsync();
-                var entitySummaries = patientItem.FindEntities(t => true);
-                if (entitySummaries.Count == 2 && entitySummaries[0].Status == "completed" && entitySummaries[1].Status == "completed")
-                {
-                    var imageSetSummary = patientItem.FindEntities(t => t.Type == "image_set")[0];
-                    var entityItem = await imageSetSummary.GetAsync() as ImageSetItem;
-                    if (entityItem.Data.Images.Count == 5)
-                    {
-                        break;
-                    }
-                }
-            }
+            // Verify test folder and test file were uploaded
+            await patientItem.RefreshAsync();
+            var entitySummaries = patientItem.FindEntities(t => true);
+            Assert.AreEqual(2, entitySummaries.Count);
+            var imageSetSummary = patientItem.FindEntities(t => t.Type == "image_set")[0];
+            var entityItem = await imageSetSummary.GetAsync() as ImageSetItem;
+            Assert.AreEqual(5, entityItem.Data.Images.Count);
+            Assert.AreEqual(1, patientItem.FindEntities(t => t.Type == "structure_set").Count);
         }
     }
 }

--- a/proknow-sdk-test/PatientTest/PatientSummaryTest.cs
+++ b/proknow-sdk-test/PatientTest/PatientSummaryTest.cs
@@ -11,72 +11,77 @@ namespace ProKnow.Patient.Test
     [TestClass]
     public class PatientSummaryTest
     {
-        private static readonly string _patientMrnAndName = "SDK-PatientSummaryTest";
+        private static readonly string _testClassName = nameof(PatientSummaryTest);
         private static readonly ProKnowApi _proKnow = TestSettings.ProKnow;
-        private static string _workspaceId;
-        private static PatientSummary _patientSummary;
 
         [ClassInitialize]
 #pragma warning disable IDE0060 // Remove unused parameter
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test workspace, if necessary
-            await TestHelper.DeleteWorkspaceAsync(_patientMrnAndName);
-
-            // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName);
-            _workspaceId = workspaceItem.Id;
-
-            // Create a test patient
-            _patientSummary = await TestHelper.CreatePatientAsync(_patientMrnAndName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
         }
 
         [ClassCleanup]
         public static async Task ClassCleanup()
         {
-            // Delete test workspace
-            await _proKnow.Workspaces.DeleteAsync(_workspaceId);
+            // Delete test workspaces
+            await TestHelper.DeleteWorkspacesAsync(_testClassName);
         }
 
         [TestMethod]
         public async Task GetAsyncTest()
         {
+            int testNumber = 1;
+
+            // Create a workspace
+            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+
+            // Create a patient
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber);
+            var patientSummary = await _proKnow.Patients.FindAsync(workspaceItem.Id, p => p.Id == patientItem.Id);
+
             // Get the patient item
-            var patientItem = await _patientSummary.GetAsync();
+            var createdPatientItem = await patientSummary.GetAsync();
 
             // Verify the returned patient item
-            Assert.AreEqual(_patientSummary.Id, patientItem.Id);
-            Assert.AreEqual(_patientSummary.Mrn, patientItem.Mrn);
-            Assert.AreEqual(_patientSummary.Name, patientItem.Name);
-            Assert.AreEqual(_patientSummary.BirthDate, patientItem.BirthDate);
-            Assert.AreEqual(_patientSummary.Sex, patientItem.Sex);
+            Assert.AreEqual(patientSummary.Id, createdPatientItem.Id);
+            Assert.AreEqual(patientSummary.Mrn, createdPatientItem.Mrn);
+            Assert.AreEqual(patientSummary.Name, createdPatientItem.Name);
+            Assert.AreEqual(patientSummary.BirthDate, createdPatientItem.BirthDate);
+            Assert.AreEqual(patientSummary.Sex, createdPatientItem.Sex);
         }
 
         [TestMethod]
         public async Task UploadAsyncTest_SingleFile()
         {
+            int testNumber = 2;
+
+            // Create a workspace
+            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+
+            // Create a patient
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber);
+            var patientSummary = await _proKnow.Patients.FindAsync(workspaceItem.Id, p => p.Id == patientItem.Id);
+
             // Upload test file
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Becker^Matthew", "RP.dcm");
             var overrides = new UploadFileOverrides
             {
-                Patient = new PatientCreateSchema { Name = _patientMrnAndName, Mrn = _patientMrnAndName }
+                Patient = new PatientCreateSchema { Name = patientItem.Name, Mrn = patientItem.Mrn }
             };
-            var uploadBatch = await _patientSummary.UploadAsync(uploadPath, overrides);
+            await patientSummary.UploadAsync(uploadPath, overrides);
 
-            // Wait until uploaded test file has processed
-            PatientItem patientItem;
+            // Verify file was uploaded
             while (true)
             {
-                patientItem = await _patientSummary.GetAsync();
+                await patientItem.RefreshAsync();
                 var entitySummaries = patientItem.FindEntities(t => t.Type == "plan");
                 if (entitySummaries.Count > 0 && entitySummaries[0].Status == "completed")
                 {
                     // Make sure the uploaded data is the same
-                    Assert.AreEqual(entitySummaries[0].Uid, "2.16.840.1.114337.1.1.1535997926.0");
-
-                    // Cleanup (in case there are other tests using the same patient)
-                    await entitySummaries[0].DeleteAsync();
+                    Assert.AreEqual("2.16.840.1.114337.1.1.1535997926.0", entitySummaries[0].Uid);
 
                     break;
                 }
@@ -86,31 +91,36 @@ namespace ProKnow.Patient.Test
         [TestMethod]
         public async Task UploadAsyncTest_SingleFolder()
         {
+            int testNumber = 3;
+
+            // Create a workspace
+            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+
+            // Create a patient
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber);
+            var patientSummary = await _proKnow.Patients.FindAsync(workspaceItem.Id, p => p.Id == patientItem.Id);
+
             // Upload test folder
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Becker^Matthew", "CT");
             var overrides = new UploadFileOverrides
             {
-                Patient = new PatientCreateSchema { Name = _patientMrnAndName, Mrn = _patientMrnAndName }
+                Patient = new PatientCreateSchema { Name = patientItem.Name, Mrn = patientItem.Mrn }
             };
-            var uploadBatch = await _patientSummary.UploadAsync(uploadPath, overrides);
+            await patientSummary.UploadAsync(uploadPath, overrides);
 
-            // Wait until uploaded test files have processed
+            // Very all files were uploaded
             var uploadedFiles = Directory.GetFiles(uploadPath);
-            PatientItem patientItem;
             while (true)
             {
-                patientItem = await _patientSummary.GetAsync();
+                await patientItem.RefreshAsync();
                 var entitySummaries = patientItem.FindEntities(t => t.Type == "image_set");
                 if (entitySummaries.Count > 0 && entitySummaries[0].Status == "completed")
                 {
-                    // Make sure the uploaded data is the same
                     var entityItem = await entitySummaries[0].GetAsync() as ImageSetItem;
                     if (entityItem.Data.Images.Count == uploadedFiles.Length)
-
-                        // Cleanup (in case there are other tests using the same image set)
-                        await entityItem.DeleteAsync();
-
-                    break;
+                    {
+                        break;
+                    }
                 }
             }
         }
@@ -118,49 +128,50 @@ namespace ProKnow.Patient.Test
         [TestMethod]
         public async Task UploadAsyncTest_MultipleFilesAndOrFolders()
         {
+            int testNumber = 4;
+
+            // Create a workspace
+            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+
+            // Create a patient
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber);
+            var patientSummary = await _proKnow.Patients.FindAsync(workspaceItem.Id, p => p.Id == patientItem.Id);
+
             // Upload test folder and file
             var uploadPath1 = Path.Combine(TestSettings.TestDataRootDirectory, "Becker^Matthew", "CT");
             var uploadPath2 = Path.Combine(TestSettings.TestDataRootDirectory, "Becker^Matthew", "RP.dcm");
             var uploadPaths = new List<string>() { uploadPath1, uploadPath2 };
             var overrides = new UploadFileOverrides
             {
-                Patient = new PatientCreateSchema { Name = _patientMrnAndName, Mrn = _patientMrnAndName }
+                Patient = new PatientCreateSchema { Name = patientItem.Name, Mrn = patientItem.Mrn }
             };
-            var uploadBatch = await _patientSummary.UploadAsync(uploadPaths, overrides);
+            await patientSummary.UploadAsync(uploadPaths, overrides);
 
-
-            // Wait until uploaded CT files have processed
+            // Verify all CT files were uploaded
             var uploadedCtFiles = Directory.GetFiles(uploadPath1);
-            PatientItem patientItem;
             while (true)
             {
-                patientItem = await _patientSummary.GetAsync();
+                await patientItem.RefreshAsync();
                 var entitySummaries = patientItem.FindEntities(t => t.Type == "image_set");
                 if (entitySummaries.Count > 0 && entitySummaries[0].Status == "completed")
                 {
-                    // Make sure the uploaded data is the same
                     var entityItem = await entitySummaries[0].GetAsync() as ImageSetItem;
                     if (entityItem.Data.Images.Count == uploadedCtFiles.Length)
-
-                        // Cleanup (in case there are other tests using the same image set)
-                        await entityItem.DeleteAsync();
-
-                    break;
+                    {
+                        break;
+                    }
                 }
             }
 
-            // Wait until upload plan file has processed
+            // Verify plan file was uploaded
             while (true)
             {
-                patientItem = await _patientSummary.GetAsync();
+                await patientItem.RefreshAsync();
                 var entitySummaries = patientItem.FindEntities(t => t.Type == "plan");
                 if (entitySummaries.Count > 0 && entitySummaries[0].Status == "completed")
                 {
                     // Make sure the uploaded data is the same
-                    Assert.AreEqual(entitySummaries[0].Uid, "2.16.840.1.114337.1.1.1535997926.0");
-
-                    // Cleanup (in case there are other tests using the same patient)
-                    await entitySummaries[0].DeleteAsync();
+                    Assert.AreEqual("2.16.840.1.114337.1.1.1535997926.0", entitySummaries[0].Uid);
 
                     break;
                 }

--- a/proknow-sdk-test/PatientTest/PatientSummaryTest.cs
+++ b/proknow-sdk-test/PatientTest/PatientSummaryTest.cs
@@ -74,18 +74,10 @@ namespace ProKnow.Patient.Test
             await patientSummary.UploadAsync(uploadPath, overrides);
 
             // Verify file was uploaded
-            while (true)
-            {
-                await patientItem.RefreshAsync();
-                var entitySummaries = patientItem.FindEntities(t => t.Type == "plan");
-                if (entitySummaries.Count > 0 && entitySummaries[0].Status == "completed")
-                {
-                    // Make sure the uploaded data is the same
-                    Assert.AreEqual("2.16.840.1.114337.1.1.1535997926.0", entitySummaries[0].Uid);
-
-                    break;
-                }
-            }
+            await patientItem.RefreshAsync();
+            var entitySummaries = patientItem.FindEntities(t => t.Type == "plan");
+            Assert.AreEqual(1, entitySummaries.Count);
+            Assert.AreEqual("2.16.840.1.114337.1.1.1535997926.0", entitySummaries[0].Uid);
         }
 
         [TestMethod]
@@ -110,19 +102,11 @@ namespace ProKnow.Patient.Test
 
             // Very all files were uploaded
             var uploadedFiles = Directory.GetFiles(uploadPath);
-            while (true)
-            {
-                await patientItem.RefreshAsync();
-                var entitySummaries = patientItem.FindEntities(t => t.Type == "image_set");
-                if (entitySummaries.Count > 0 && entitySummaries[0].Status == "completed")
-                {
-                    var entityItem = await entitySummaries[0].GetAsync() as ImageSetItem;
-                    if (entityItem.Data.Images.Count == uploadedFiles.Length)
-                    {
-                        break;
-                    }
-                }
-            }
+            await patientItem.RefreshAsync();
+            var entitySummaries = patientItem.FindEntities(t => t.Type == "image_set");
+            Assert.AreEqual(1, entitySummaries.Count);
+            var entityItem = await entitySummaries[0].GetAsync() as ImageSetItem;
+            Assert.AreEqual(uploadedFiles.Length, entityItem.Data.Images.Count);
         }
 
         [TestMethod]
@@ -149,33 +133,17 @@ namespace ProKnow.Patient.Test
 
             // Verify all CT files were uploaded
             var uploadedCtFiles = Directory.GetFiles(uploadPath1);
-            while (true)
-            {
-                await patientItem.RefreshAsync();
-                var entitySummaries = patientItem.FindEntities(t => t.Type == "image_set");
-                if (entitySummaries.Count > 0 && entitySummaries[0].Status == "completed")
-                {
-                    var entityItem = await entitySummaries[0].GetAsync() as ImageSetItem;
-                    if (entityItem.Data.Images.Count == uploadedCtFiles.Length)
-                    {
-                        break;
-                    }
-                }
-            }
+            await patientItem.RefreshAsync();
+            var entitySummaries = patientItem.FindEntities(t => t.Type == "image_set");
+            Assert.AreEqual(1, entitySummaries.Count);
+            var entityItem = await entitySummaries[0].GetAsync() as ImageSetItem;
+            Assert.AreEqual(uploadedCtFiles.Length, entityItem.Data.Images.Count);
 
             // Verify plan file was uploaded
-            while (true)
-            {
-                await patientItem.RefreshAsync();
-                var entitySummaries = patientItem.FindEntities(t => t.Type == "plan");
-                if (entitySummaries.Count > 0 && entitySummaries[0].Status == "completed")
-                {
-                    // Make sure the uploaded data is the same
-                    Assert.AreEqual("2.16.840.1.114337.1.1.1535997926.0", entitySummaries[0].Uid);
-
-                    break;
-                }
-            }
+            await patientItem.RefreshAsync();
+            entitySummaries = patientItem.FindEntities(t => t.Type == "plan");
+            Assert.AreEqual(1, entitySummaries.Count);
+            Assert.AreEqual("2.16.840.1.114337.1.1.1535997926.0", entitySummaries[0].Uid);
         }
     }
 }

--- a/proknow-sdk-test/PatientTest/RegistrationsTest/SroItemTest.cs
+++ b/proknow-sdk-test/PatientTest/RegistrationsTest/SroItemTest.cs
@@ -8,22 +8,18 @@ namespace ProKnow.Patient.Registrations.Test
     [TestClass]
     public class SroItemTest
     {
-        private static readonly string _patientMrnAndName = "SDK-SroItemTest";
-        private static readonly string _downloadFolderRoot = Path.Combine(Path.GetTempPath(), _patientMrnAndName);
+        private static readonly string _testClassName = nameof(SroItemTest);
+        private static readonly string _downloadFolderRoot = Path.Combine(Path.GetTempPath(), _testClassName);
 
         [ClassInitialize]
 #pragma warning disable IDE0060 // Remove unused parameter
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test workspace, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
 
             // Create download folder root
-            if (Directory.Exists(_downloadFolderRoot))
-            {
-                Directory.Delete(_downloadFolderRoot, true);
-            }
             Directory.CreateDirectory(_downloadFolderRoot);
         }
 
@@ -31,7 +27,7 @@ namespace ProKnow.Patient.Registrations.Test
         public static async Task ClassCleanup()
         {
             // Delete test workspaces
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            await TestHelper.DeleteWorkspacesAsync(_testClassName);
 
             // Delete download folder
             if (Directory.Exists(_downloadFolderRoot))
@@ -46,10 +42,10 @@ namespace ProKnow.Patient.Registrations.Test
             var testNumber = 1;
 
             // Create a test workspace
-            await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Sro", "reg.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Sro", "reg.dcm"), 1);
             var sroSummary = patientItem.Studies[0].Sros[0];
             var sroItem = await sroSummary.GetAsync();
 
@@ -73,10 +69,10 @@ namespace ProKnow.Patient.Registrations.Test
             var testNumber = 2;
 
             // Create a test workspace
-            await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Sro", "reg.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Sro", "reg.dcm"), 1);
             var sroSummary = patientItem.Studies[0].Sros[0];
             var sroItem = await sroSummary.GetAsync();
 
@@ -101,10 +97,10 @@ namespace ProKnow.Patient.Registrations.Test
             var testNumber = 3;
 
             // Create a test workspace
-            await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Sro", "reg.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Sro", "reg.dcm"), 1);
             var sroSummary = patientItem.Studies[0].Sros[0];
             var sroItem = await sroSummary.GetAsync();
 
@@ -127,10 +123,10 @@ namespace ProKnow.Patient.Registrations.Test
             var testNumber = 4;
 
             // Create a test workspace
-            await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, Path.Combine("Sro", "reg.dcm"), 1);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Sro", "reg.dcm"), 1);
             var sroSummary = patientItem.Studies[0].Sros[0];
             var sroItem = await sroSummary.GetAsync();
 

--- a/proknow-sdk-test/PatientTest/RegistrationsTest/SroSummaryTest.cs
+++ b/proknow-sdk-test/PatientTest/RegistrationsTest/SroSummaryTest.cs
@@ -8,22 +8,18 @@ namespace ProKnow.Patient.Registrations.Test
     [TestClass]
     public class SroSummaryTest
     {
-        private static readonly string _patientMrnAndName = "SDK-SroSummaryTest";
-        private static readonly string _downloadFolderRoot = Path.Combine(Path.GetTempPath(), _patientMrnAndName);
+        private static readonly string _testClassName = nameof(SroSummaryTest);
+        private static readonly string _downloadFolderRoot = Path.Combine(Path.GetTempPath(), _testClassName);
 
         [ClassInitialize]
 #pragma warning disable IDE0060 // Remove unused parameter
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test workspace, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
 
             // Create download folder root
-            if (Directory.Exists(_downloadFolderRoot))
-            {
-                Directory.Delete(_downloadFolderRoot, true);
-            }
             Directory.CreateDirectory(_downloadFolderRoot);
         }
 
@@ -31,7 +27,7 @@ namespace ProKnow.Patient.Registrations.Test
         public static async Task ClassCleanup()
         {
             // Delete test workspaces
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            await TestHelper.DeleteWorkspacesAsync(_testClassName);
 
             // Delete download folder
             if (Directory.Exists(_downloadFolderRoot))
@@ -46,10 +42,10 @@ namespace ProKnow.Patient.Registrations.Test
             var testNumber = 1;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Sro", 3);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Sro", 3);
 
             // Get the full representation of the image sets and SRO
             var ctImageSetItem = await patientItem.FindEntities(e => e.Modality == "CT")[0].GetAsync();

--- a/proknow-sdk-test/PatientTest/StudySummaryTest.cs
+++ b/proknow-sdk-test/PatientTest/StudySummaryTest.cs
@@ -9,22 +9,18 @@ namespace ProKnow.Patient.Test
     [TestClass]
     public class StudySummaryTest
     {
-        private static readonly string _patientMrnAndName = "SDK-StudySummaryTest";
-        private static readonly string _downloadFolderRoot = Path.Combine(Path.GetTempPath(), _patientMrnAndName);
+        private static readonly string _testClassName = nameof(StudySummaryTest);
+        private static readonly string _downloadFolderRoot = Path.Combine(Path.GetTempPath(), _testClassName);
 
         [ClassInitialize]
 #pragma warning disable IDE0060 // Remove unused parameter
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test workspace, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
 
             // Create download folder root
-            if (Directory.Exists(_downloadFolderRoot))
-            {
-                Directory.Delete(_downloadFolderRoot, true);
-            }
             Directory.CreateDirectory(_downloadFolderRoot);
         }
 
@@ -32,7 +28,7 @@ namespace ProKnow.Patient.Test
         public static async Task ClassCleanup()
         {
             // Delete test workspaces
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            await TestHelper.DeleteWorkspacesAsync(_testClassName);
 
             // Delete download folder
             if (Directory.Exists(_downloadFolderRoot))
@@ -47,10 +43,10 @@ namespace ProKnow.Patient.Test
             int testNumber = 1;
 
             // Create a workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a test patient
-            var patientItem = await TestHelper.CreatePatientAsync(_patientMrnAndName, testNumber, "Sro", 3);
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, "Sro", 3);
             var studySummary = patientItem.Studies.Where(s => s.Sros.Count() > 0).First();
             var ctImageSetItem = await patientItem.FindEntities(e => e.Modality == "CT")[0].GetAsync();
             var mrImageSetItem = await patientItem.FindEntities(e => e.Modality == "MR")[0].GetAsync();

--- a/proknow-sdk-test/RequestorTest.cs
+++ b/proknow-sdk-test/RequestorTest.cs
@@ -23,14 +23,10 @@ namespace ProKnow.Test
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test workspaces, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_testClassName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
 
             // Create download folder root
-            if (Directory.Exists(_downloadFolderRoot))
-            {
-                Directory.Delete(_downloadFolderRoot, true);
-            }
             Directory.CreateDirectory(_downloadFolderRoot);
         }
 
@@ -93,7 +89,7 @@ namespace ProKnow.Test
             var workspaceItems = JsonSerializer.Deserialize<IList<WorkspaceItem>>(json);
 
             // Verify that the created workspace was one of the workspaces returned
-            Assert.IsNotNull(await _proKnow.Workspaces.FindAsync(w => w.Name == workspaceItem.Name));
+            Assert.IsTrue(workspaceItems.Any(w => w.Name == workspaceItem.Name));
         }
 
         [TestMethod]
@@ -116,7 +112,7 @@ namespace ProKnow.Test
             int testNumber = 5;
 
             // Create a workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Create a patient with an image set
             var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "CT"), 1);
@@ -256,7 +252,6 @@ namespace ProKnow.Test
                 {
                     // Stream the document to a new file using the Requestor object
                     var outputDocumentPath = Path.Combine(_downloadFolderRoot, testNumber.ToString(), "test.pdf");
-                    var documentName = Path.GetFileName(outputDocumentPath);
                     var route = $"/workspaces/{workspaceItem.Id}/patients/{patientItem.Id}/documents/{documentSummary.Id}/{documentSummary.Name}";
                     await _proKnow.Requestor.StreamAsync(route, outputDocumentPath);
 

--- a/proknow-sdk-test/ScorecardTest/CustomMetricItemTest.cs
+++ b/proknow-sdk-test/ScorecardTest/CustomMetricItemTest.cs
@@ -8,52 +8,56 @@ namespace ProKnow.Scorecard.Test
     public class CustomMetricItemTest
     {
         private static readonly ProKnowApi _proKnow = TestSettings.ProKnow;
-        private static readonly string _baseName = "SDK-CustomMetricItemTest";
+        private static readonly string _testClassName = nameof(CustomMetricItemTest);
 
         [TestInitialize]
         public async Task ClassInitialize()
         {
-            // Delete existing custom metrics, if necessary
-            await TestHelper.DeleteCustomMetricsAsync(_baseName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
         }
 
         [TestCleanup]
         public async Task ClassCleanup()
         {
             // Delete custom metrics created for this test
-            await TestHelper.DeleteCustomMetricsAsync(_baseName);
+            await TestHelper.DeleteCustomMetricsAsync(_testClassName);
         }
 
         [TestMethod]
         public async Task DeleteAsyncTest()
         {
+            var testNumber = 1;
+
             // Create a custom metric
-            var customMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_baseName}-1", "dose", "number");
+            var customMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}", "dose", "number");
 
             // Verify it was created
-            Assert.IsNotNull(await _proKnow.CustomMetrics.FindAsync(t => t.Name == $"{_baseName}-1"));
+            Assert.IsNotNull(await _proKnow.CustomMetrics.FindAsync(t => t.Name == $"{_testClassName}-{testNumber}"));
 
             // Delete it
             await customMetricItem.DeleteAsync();
 
             // Verify it was deleted
-            Assert.IsNull(await _proKnow.CustomMetrics.FindAsync(t => t.Name == $"{_baseName}-1"));
+            Assert.IsNull(await _proKnow.CustomMetrics.FindAsync(t => t.Name == $"{_testClassName}-{testNumber}"));
         }
 
         [TestMethod]
         public async Task SaveAsyncTest()
         {
+            var testNumber = 2;
+
             // Create a custom metric
-            var customMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_baseName}-2", "plan", "number");
+            var customMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}", "plan", "number");
 
             // Change the name and context and save the changes
-            customMetricItem.Name = $"{_baseName}-2a";
+            customMetricItem.Name = $"{_testClassName}-{testNumber}a";
             customMetricItem.Context = "structure_set";
             await customMetricItem.SaveAsync();
 
             // Verify the changes were saved
-            Assert.IsNull(await _proKnow.CustomMetrics.FindAsync(t => t.Name == $"{_baseName}-2"));
-            var savedCustomMetricItem = await _proKnow.CustomMetrics.FindAsync(t => t.Name == $"{_baseName}-2a");
+            Assert.IsNull(await _proKnow.CustomMetrics.FindAsync(t => t.Name == $"{_testClassName}-{testNumber}"));
+            var savedCustomMetricItem = await _proKnow.CustomMetrics.FindAsync(t => t.Name == $"{_testClassName}-{testNumber}a");
             Assert.AreEqual("structure_set", savedCustomMetricItem.Context);
         }
     }

--- a/proknow-sdk-test/ScorecardTest/CustomMetricsTest.cs
+++ b/proknow-sdk-test/ScorecardTest/CustomMetricsTest.cs
@@ -9,136 +9,209 @@ namespace ProKnow.Scorecard.Test
     public class CustomMetricsTest
     {
         private static readonly ProKnowApi _proKnow = TestSettings.ProKnow;
-        private static readonly string _baseName = "SDK-CustomMetricsTest";
-        private static CustomMetricItem _enumCustomMetricItem;
-        private static CustomMetricItem _numberCustomMetricItem;
-        private static CustomMetricItem _stringCustomMetricItem;
+        private static readonly string _testClassName = nameof(CustomMetricsTest);
 
         [TestInitialize]
         public async Task ClassInitialize()
         {
-            // Delete existing custom metrics, if necessary
-            await TestHelper.DeleteCustomMetricsAsync(_baseName);
-
-            // Create custom metrics for testing
-            _enumCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_baseName}-enum", "patient", "enum",
-                new string[] { "one", "two", "three" });
-            _numberCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_baseName}-number", "dose", "number");
-            _stringCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_baseName}-string", "plan", "string");
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
         }
 
         [TestCleanup]
         public async Task ClassCleanup()
         {
-            // Delete custom metrics created for this test
-            await TestHelper.DeleteCustomMetricsAsync(_baseName);
+            // Delete custom metrics
+            await TestHelper.DeleteCustomMetricsAsync(_testClassName);
         }
 
         [TestMethod]
-        public void CreateAsyncTest()
+        public async Task CreateAsyncTest()
         {
-            // Verify creation of the enum custom metric in ClassInitialize
-            Assert.AreEqual("SDK-CustomMetricsTest-enum", _enumCustomMetricItem.Name);
-            Assert.AreEqual("patient", _enumCustomMetricItem.Context);
-            Assert.IsNotNull(_enumCustomMetricItem.Type.Enum);
-            Assert.AreEqual(3, _enumCustomMetricItem.Type.Enum.Values.Length);
-            Assert.IsNull(_enumCustomMetricItem.Type.Number);
-            Assert.IsNull(_enumCustomMetricItem.Type.String);
+            var testNumber = 1;
 
-            // Verify creation of the number custom metric in ClassInitialize
-            Assert.AreEqual("SDK-CustomMetricsTest-number", _numberCustomMetricItem.Name);
-            Assert.AreEqual("dose", _numberCustomMetricItem.Context);
-            Assert.IsNull(_numberCustomMetricItem.Type.Enum);
-            Assert.IsNotNull(_numberCustomMetricItem.Type.Number);
-            Assert.IsNull(_numberCustomMetricItem.Type.String);
+            // Create custom metrics
+            var enumCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-enum", "patient", "enum",
+                new string[] { "one", "two", "three" });
+            var numberCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-number", "dose", "number");
+            var stringCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-string", "plan", "string");
 
-            // Verify creation of the string custom metric in ClassInitialize
-            Assert.AreEqual("SDK-CustomMetricsTest-string", _stringCustomMetricItem.Name);
-            Assert.AreEqual("plan", _stringCustomMetricItem.Context);
-            Assert.IsNull(_stringCustomMetricItem.Type.Enum);
-            Assert.IsNull(_stringCustomMetricItem.Type.Number);
-            Assert.IsNotNull(_stringCustomMetricItem.Type.String);
-        }
-
-        [TestMethod]
-        public async Task DeleteAsyncTest()
-        {
-            await _proKnow.CustomMetrics.DeleteAsync(_enumCustomMetricItem.Id);
-            await _proKnow.CustomMetrics.DeleteAsync(_numberCustomMetricItem.Id);
-            await _proKnow.CustomMetrics.DeleteAsync(_stringCustomMetricItem.Id);
-            var customMetrics = await _proKnow.CustomMetrics.QueryAsync();
-            Assert.IsNull(customMetrics.FirstOrDefault(c => c.Name.Contains(_baseName)));
-        }
-
-        [TestMethod]
-        public async Task FindAsyncTest()
-        {
-            var customMetric = await _proKnow.CustomMetrics.FindAsync(m => m.Name == _numberCustomMetricItem.Name);
-            Assert.AreEqual(_numberCustomMetricItem.Id, customMetric.Id);
-        }
-
-        [TestMethod]
-        public async Task QueryAsyncTest()
-        {
-            var customMetrics = await _proKnow.CustomMetrics.QueryAsync();
-
-            // enum custom metric
-            var enumCustomMetricItem = customMetrics.First(c => c.Name == $"{_baseName}-enum");
-            Assert.AreEqual(_enumCustomMetricItem.Id, enumCustomMetricItem.Id);
-            Assert.AreEqual(_enumCustomMetricItem.Name, enumCustomMetricItem.Name);
-            Assert.AreEqual(_enumCustomMetricItem.Context, enumCustomMetricItem.Context);
-            Assert.AreEqual(3, enumCustomMetricItem.Type.Enum.Values.Count());
-            Assert.AreEqual(_enumCustomMetricItem.Type.Enum.Values[0], enumCustomMetricItem.Type.Enum.Values[0]);
-            Assert.AreEqual(_enumCustomMetricItem.Type.Enum.Values[1], enumCustomMetricItem.Type.Enum.Values[1]);
-            Assert.AreEqual(_enumCustomMetricItem.Type.Enum.Values[2], enumCustomMetricItem.Type.Enum.Values[2]);
+            // Verify creation of the enum custom metric
+            Assert.AreEqual($"{_testClassName}-{testNumber}-enum", enumCustomMetricItem.Name);
+            Assert.AreEqual("patient", enumCustomMetricItem.Context);
+            Assert.IsNotNull(enumCustomMetricItem.Type.Enum);
+            Assert.AreEqual(3, enumCustomMetricItem.Type.Enum.Values.Length);
             Assert.IsNull(enumCustomMetricItem.Type.Number);
             Assert.IsNull(enumCustomMetricItem.Type.String);
 
-            // number custom metric
-            var numberCustomMetricItem = customMetrics.First(c => c.Name == $"{_baseName}-number");
-            Assert.AreEqual(_numberCustomMetricItem.Id, numberCustomMetricItem.Id);
-            Assert.AreEqual(_numberCustomMetricItem.Name, numberCustomMetricItem.Name);
-            Assert.AreEqual(_numberCustomMetricItem.Context, numberCustomMetricItem.Context);
+            // Verify creation of the number custom metric
+            Assert.AreEqual($"{_testClassName}-{testNumber}-number", numberCustomMetricItem.Name);
+            Assert.AreEqual("dose", numberCustomMetricItem.Context);
             Assert.IsNull(numberCustomMetricItem.Type.Enum);
             Assert.IsNotNull(numberCustomMetricItem.Type.Number);
             Assert.IsNull(numberCustomMetricItem.Type.String);
 
-            // string custom metric
-            var stringCustomMetricItem = customMetrics.First(c => c.Name == $"{_baseName}-string");
-            Assert.AreEqual(_stringCustomMetricItem.Id, stringCustomMetricItem.Id);
-            Assert.AreEqual(_stringCustomMetricItem.Name, stringCustomMetricItem.Name);
-            Assert.AreEqual(_stringCustomMetricItem.Context, stringCustomMetricItem.Context);
+            // Verify creation of the string custom metric
+            Assert.AreEqual($"{_testClassName}-{testNumber}-string", stringCustomMetricItem.Name);
+            Assert.AreEqual("plan", stringCustomMetricItem.Context);
             Assert.IsNull(stringCustomMetricItem.Type.Enum);
             Assert.IsNull(stringCustomMetricItem.Type.Number);
             Assert.IsNotNull(stringCustomMetricItem.Type.String);
         }
 
         [TestMethod]
+        public async Task DeleteAsyncTest()
+        {
+            var testNumber = 2;
+
+            // Create a custom metric
+            var numberCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-number", "dose", "number");
+
+            // Delete it
+            await _proKnow.CustomMetrics.DeleteAsync(numberCustomMetricItem.Id);
+
+            // Verify that the custom metric was deleted
+            var customMetrics = await _proKnow.CustomMetrics.QueryAsync();
+            Assert.IsNull(customMetrics.FirstOrDefault(c => c.Id == numberCustomMetricItem.Id));
+        }
+
+        [TestMethod]
+        public async Task FindAsyncTest()
+        {
+            var testNumber = 3;
+
+            // Create custom metrics
+            await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-enum", "patient", "enum",
+                new string[] { "one", "two", "three" });
+            var numberCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-number", "dose", "number");
+            await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-string", "plan", "string");
+
+            // Find a custom metric
+            var customMetric = await _proKnow.CustomMetrics.FindAsync(m => m.Name == numberCustomMetricItem.Name);
+
+            // Verify that the custom metric was found
+            Assert.AreEqual(numberCustomMetricItem.Id, customMetric.Id);
+        }
+
+        [TestMethod]
+        public async Task QueryAsyncTest()
+        {
+            var testNumber = 4;
+
+            // Create custom metrics
+            var expectedEnumCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-enum", "patient", "enum",
+                new string[] { "one", "two", "three" });
+            var expectedNumberCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-number", "dose", "number");
+            var expectedStringCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-string", "plan", "string");
+
+            // Query for custom metrics
+            var customMetrics = await _proKnow.CustomMetrics.QueryAsync();
+
+            // Verify that the enum custom metric was returned
+            var actualEnumCustomMetricItem = customMetrics.First(c => c.Name == $"{_testClassName}-{testNumber}-enum");
+            Assert.AreEqual(expectedEnumCustomMetricItem.Id, actualEnumCustomMetricItem.Id);
+            Assert.AreEqual(expectedEnumCustomMetricItem.Name, actualEnumCustomMetricItem.Name);
+            Assert.AreEqual(expectedEnumCustomMetricItem.Context, actualEnumCustomMetricItem.Context);
+            Assert.AreEqual(3, actualEnumCustomMetricItem.Type.Enum.Values.Count());
+            Assert.AreEqual(expectedEnumCustomMetricItem.Type.Enum.Values[0], actualEnumCustomMetricItem.Type.Enum.Values[0]);
+            Assert.AreEqual(expectedEnumCustomMetricItem.Type.Enum.Values[1], actualEnumCustomMetricItem.Type.Enum.Values[1]);
+            Assert.AreEqual(expectedEnumCustomMetricItem.Type.Enum.Values[2], actualEnumCustomMetricItem.Type.Enum.Values[2]);
+            Assert.IsNull(actualEnumCustomMetricItem.Type.Number);
+            Assert.IsNull(actualEnumCustomMetricItem.Type.String);
+
+            // Verify that the number custom metric was returned
+            var actualNumberCustomMetricItem = customMetrics.First(c => c.Name == $"{_testClassName}-{testNumber}-number");
+            Assert.AreEqual(expectedNumberCustomMetricItem.Id, actualNumberCustomMetricItem.Id);
+            Assert.AreEqual(expectedNumberCustomMetricItem.Name, actualNumberCustomMetricItem.Name);
+            Assert.AreEqual(expectedNumberCustomMetricItem.Context, actualNumberCustomMetricItem.Context);
+            Assert.IsNull(actualNumberCustomMetricItem.Type.Enum);
+            Assert.IsNotNull(actualNumberCustomMetricItem.Type.Number);
+            Assert.IsNull(actualNumberCustomMetricItem.Type.String);
+
+            // Verify that the string custom metric was returned
+            var actualStringCustomMetricItem = customMetrics.First(c => c.Name == $"{_testClassName}-{testNumber}-string");
+            Assert.AreEqual(expectedStringCustomMetricItem.Id, actualStringCustomMetricItem.Id);
+            Assert.AreEqual(expectedStringCustomMetricItem.Name, actualStringCustomMetricItem.Name);
+            Assert.AreEqual(expectedStringCustomMetricItem.Context, actualStringCustomMetricItem.Context);
+            Assert.IsNull(actualStringCustomMetricItem.Type.Enum);
+            Assert.IsNull(actualStringCustomMetricItem.Type.Number);
+            Assert.IsNotNull(actualStringCustomMetricItem.Type.String);
+        }
+
+        [TestMethod]
         public async Task ResolveAsyncTest_Id()
         {
-            var customMetric = await _proKnow.CustomMetrics.ResolveAsync(_enumCustomMetricItem.Id);
-            Assert.AreEqual(_enumCustomMetricItem.Id, customMetric.Id);
+            var testNumber = 5;
+
+            // Create a custom metric
+            var stringCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-string", "plan", "string");
+
+            // Resolve the custom metric by providing ID
+            var customMetric = await _proKnow.CustomMetrics.ResolveAsync(stringCustomMetricItem.Id);
+
+            // Verify the returned custom metric
+            Assert.AreEqual(stringCustomMetricItem.Name, customMetric.Name);
+            Assert.AreEqual(stringCustomMetricItem.Context, customMetric.Context);
+            Assert.IsNull(customMetric.Type.Enum);
+            Assert.IsNull(customMetric.Type.Number);
+            Assert.IsNotNull(customMetric.Type.String);
         }
 
         [TestMethod]
         public async Task ResolveAsyncTest_Name()
         {
-            var customMetric = await _proKnow.CustomMetrics.ResolveAsync(_enumCustomMetricItem.Name);
-            Assert.AreEqual(_enumCustomMetricItem.Id, customMetric.Id);
+            var testNumber = 6;
+
+            // Create a custom metric
+            var stringCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-string", "plan", "string");
+
+            // Resolve the custom metric by providing name
+            var customMetric = await _proKnow.CustomMetrics.ResolveAsync(stringCustomMetricItem.Name);
+
+            // Verify the returned custom metric
+            Assert.AreEqual(stringCustomMetricItem.Id, customMetric.Id);
+            Assert.AreEqual(stringCustomMetricItem.Context, customMetric.Context);
+            Assert.IsNull(customMetric.Type.Enum);
+            Assert.IsNull(customMetric.Type.Number);
+            Assert.IsNotNull(customMetric.Type.String);
         }
 
         [TestMethod]
         public async Task ResolveByIdAsyncTest()
         {
-            var customMetric = await _proKnow.CustomMetrics.ResolveByIdAsync(_numberCustomMetricItem.Id);
-            Assert.AreEqual(_numberCustomMetricItem.Id, customMetric.Id);
+            var testNumber = 7;
+
+            // Create a custom metric
+            var stringCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-string", "plan", "string");
+
+            // Resolve the custom metric by ID
+            var customMetric = await _proKnow.CustomMetrics.ResolveByIdAsync(stringCustomMetricItem.Id);
+
+            // Verify the returned custom metric
+            Assert.AreEqual(stringCustomMetricItem.Name, customMetric.Name);
+            Assert.AreEqual(stringCustomMetricItem.Context, customMetric.Context);
+            Assert.IsNull(customMetric.Type.Enum);
+            Assert.IsNull(customMetric.Type.Number);
+            Assert.IsNotNull(customMetric.Type.String);
         }
 
         [TestMethod]
         public async Task ResolveByNameAsyncTest()
         {
-            var customMetric = await _proKnow.CustomMetrics.ResolveByNameAsync(_stringCustomMetricItem.Name);
-            Assert.AreEqual(_stringCustomMetricItem.Id, customMetric.Id);
+            var testNumber = 8;
+
+            // Create a custom metric
+            var stringCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}-string", "plan", "string");
+
+            // Resolve the custom metric by name
+            var customMetric = await _proKnow.CustomMetrics.ResolveByNameAsync(stringCustomMetricItem.Name);
+
+            // Verify the returned custom metric
+            Assert.AreEqual(stringCustomMetricItem.Id, customMetric.Id);
+            Assert.AreEqual(stringCustomMetricItem.Context, customMetric.Context);
+            Assert.IsNull(customMetric.Type.Enum);
+            Assert.IsNull(customMetric.Type.Number);
+            Assert.IsNotNull(customMetric.Type.String);
         }
     }
 }

--- a/proknow-sdk-test/ScorecardTest/ScorecardTemplateSummaryTest.cs
+++ b/proknow-sdk-test/ScorecardTest/ScorecardTemplateSummaryTest.cs
@@ -10,21 +10,30 @@ namespace ProKnow.Scorecard.Test
     public class ScorecardTemplateSummaryTest
     {
         private static readonly ProKnowApi _proKnow = TestSettings.ProKnow;
-        private static readonly string _baseName = "SDK-ScorecardTemplateSummaryTest";
-        private static ComputedMetric _computedMetric;
-        private static CustomMetricItem _customMetricItem;
-        private static List<ComputedMetric> _computedMetrics;
-        private static List<CustomMetric> _customMetrics;
-        private static ScorecardTemplateItem _scorecardTemplateItem;
+        private static readonly string _testClassName = nameof(ScorecardTemplateSummaryTest);
 
         [TestInitialize]
         public async Task ClassInitialize()
         {
-            // Cleanup from previous test failure, if necessary
+            // Cleanup from previous test stoppage or failure, if necessary
             await ClassCleanup();
+        }
+
+        [TestCleanup]
+        public async Task ClassCleanup()
+        {
+            // Delete scorecard template and custom metric created for this test
+            await TestHelper.DeleteScorecardTemplatesAsync(_testClassName);
+            await TestHelper.DeleteCustomMetricsAsync(_testClassName);
+        }
+
+        [TestMethod]
+        public async Task GetAsyncTest()
+        {
+            var testNumber = 1;
 
             // Create computed metric for testing
-            _computedMetric = new ComputedMetric("VOLUME_PERCENT_DOSE_RANGE_ROI", "PTV", 30, 60,
+            var expectedComputedMetric = new ComputedMetric("VOLUME_PERCENT_DOSE_RANGE_ROI", "PTV", 30, 60,
                 new List<MetricBin>() {
                     new MetricBin("IDEAL", new byte[] { Color.Green.R, Color.Green.G, Color.Green.B }),
                     new MetricBin("GOOD", new byte[] { Color.LightGreen.R, Color.LightGreen.G, Color.LightGreen.B }, 20),
@@ -34,54 +43,45 @@ namespace ProKnow.Scorecard.Test
                 });
 
             // Create custom metric for testing
-            _customMetricItem = await _proKnow.CustomMetrics.CreateAsync(_baseName, "patient", "number");
+            var expectedCustomMetricItem = await _proKnow.CustomMetrics.CreateAsync($"{_testClassName}-{testNumber}", "patient", "number");
 
             // Add objectives to custom metric
-            _customMetricItem.Objectives = new List<MetricBin>()
+            expectedCustomMetricItem.Objectives = new List<MetricBin>()
             {
                 new MetricBin("PASS", new byte[] { 18, 191, 0 }, null, 90),
                 new MetricBin("FAIL", new byte[] { 255, 0, 0 })
             };
 
-            // Create scorecard template for testing
-            _computedMetrics = new List<ComputedMetric>() { _computedMetric };
-            _customMetrics = new List<CustomMetric>() { new CustomMetric(_customMetricItem.Name, _customMetricItem.Objectives) };
-            _scorecardTemplateItem = await _proKnow.ScorecardTemplates.CreateAsync(_baseName, _computedMetrics, _customMetrics);
-        }
+            // Create a scorecard template
+            var expectedComputedMetrics = new List<ComputedMetric>() { expectedComputedMetric };
+            var expectedCustomMetrics = new List<CustomMetric>() { new CustomMetric(expectedCustomMetricItem.Name, expectedCustomMetricItem.Objectives) };
+            var expectedScorecardTemplateItem = await _proKnow.ScorecardTemplates.CreateAsync($"{_testClassName}-{testNumber}", expectedComputedMetrics, expectedCustomMetrics);
+            var expectedScorecardTemplateSummary = await _proKnow.ScorecardTemplates.FindAsync(t => t.Id == expectedScorecardTemplateItem.Id);
 
-        [TestCleanup]
-        public async Task ClassCleanup()
-        {
-            // Delete scorecard template and custom metric created for this test
-            await TestHelper.DeleteScorecardTemplatesAsync(_baseName);
-            await TestHelper.DeleteCustomMetricsAsync(_baseName);
-        }
+            // Get that scorecard template from its summary
+            var actualScorecardTemplateItem = await expectedScorecardTemplateSummary.GetAsync();
 
-        [TestMethod]
-        public async Task GetAsyncTest()
-        {
-            var scorecardTemplate = await _proKnow.ScorecardTemplates.FindAsync(t => t.Id == _scorecardTemplateItem.Id);
-            var scorecardTemplateItem = await scorecardTemplate.GetAsync();
-            Assert.AreEqual(_baseName, scorecardTemplateItem.Name);
-            Assert.AreEqual(1, scorecardTemplateItem.ComputedMetrics.Count);
-            var computedMetric = scorecardTemplateItem.ComputedMetrics[0];
-            Assert.AreEqual(_computedMetric.Type, computedMetric.Type);
-            Assert.AreEqual(_computedMetric.RoiName, computedMetric.RoiName);
-            Assert.AreEqual(_computedMetric.Arg1, computedMetric.Arg1);
-            Assert.AreEqual(_computedMetric.Arg2, computedMetric.Arg2);
-            Assert.AreEqual(_computedMetric.Objectives.Count, computedMetric.Objectives.Count);
-            for (var i = 0; i < _computedMetric.Objectives.Count; i++)
+            // Verify the returned scorecard template
+            Assert.AreEqual(expectedScorecardTemplateItem.Name, actualScorecardTemplateItem.Name);
+            Assert.AreEqual(1, actualScorecardTemplateItem.ComputedMetrics.Count);
+            var actualComputedMetric = actualScorecardTemplateItem.ComputedMetrics[0];
+            Assert.AreEqual(expectedComputedMetric.Type, actualComputedMetric.Type);
+            Assert.AreEqual(expectedComputedMetric.RoiName, actualComputedMetric.RoiName);
+            Assert.AreEqual(expectedComputedMetric.Arg1, actualComputedMetric.Arg1);
+            Assert.AreEqual(expectedComputedMetric.Arg2, actualComputedMetric.Arg2);
+            Assert.AreEqual(expectedComputedMetric.Objectives.Count, actualComputedMetric.Objectives.Count);
+            for (var i = 0; i < actualComputedMetric.Objectives.Count; i++)
             {
-                Assert.AreEqual(_computedMetric.Objectives[i].Label, computedMetric.Objectives[i].Label);
-                Assert.AreEqual(_computedMetric.Objectives[i].Color[0], computedMetric.Objectives[i].Color[0]);
-                Assert.AreEqual(_computedMetric.Objectives[i].Color[1], computedMetric.Objectives[i].Color[1]);
-                Assert.AreEqual(_computedMetric.Objectives[i].Color[2], computedMetric.Objectives[i].Color[2]);
-                Assert.AreEqual(_computedMetric.Objectives[i].Min, computedMetric.Objectives[i].Min);
-                Assert.AreEqual(_computedMetric.Objectives[i].Max, computedMetric.Objectives[i].Max);
+                Assert.AreEqual(expectedComputedMetric.Objectives[i].Label, actualComputedMetric.Objectives[i].Label);
+                Assert.AreEqual(expectedComputedMetric.Objectives[i].Color[0], actualComputedMetric.Objectives[i].Color[0]);
+                Assert.AreEqual(expectedComputedMetric.Objectives[i].Color[1], actualComputedMetric.Objectives[i].Color[1]);
+                Assert.AreEqual(expectedComputedMetric.Objectives[i].Color[2], actualComputedMetric.Objectives[i].Color[2]);
+                Assert.AreEqual(expectedComputedMetric.Objectives[i].Min, actualComputedMetric.Objectives[i].Min);
+                Assert.AreEqual(expectedComputedMetric.Objectives[i].Max, actualComputedMetric.Objectives[i].Max);
             }
-            Assert.AreEqual(1, scorecardTemplateItem.CustomMetrics.Count);
-            var customMetricItem = scorecardTemplateItem.CustomMetrics[0];
-            Assert.AreEqual(_customMetricItem.Id, customMetricItem.Id);
+            Assert.AreEqual(1, actualScorecardTemplateItem.CustomMetrics.Count);
+            var actualCustomMetricItem = expectedScorecardTemplateItem.CustomMetrics[0];
+            Assert.AreEqual(expectedCustomMetricItem.Id, actualCustomMetricItem.Id);
         }
     }
 }

--- a/proknow-sdk-test/TestHelper.cs
+++ b/proknow-sdk-test/TestHelper.cs
@@ -1,4 +1,5 @@
-﻿using ProKnow.Patient;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProKnow.Patient;
 using ProKnow.Upload;
 using System;
 using System.Collections.Generic;
@@ -11,20 +12,30 @@ namespace ProKnow.Test
     /// <summary>
     /// Test utilities
     /// </summary>
+    [TestClass]
     public static class TestHelper
     {
         private static readonly ProKnowApi _proKnow = TestSettings.ProKnow;
 
-        /// <summary>
-        /// Creates a test patient asynchronously
-        /// </summary>
-        /// <param name="testClassName">The test class name</param>
-        /// <returns>The summary of the created patient</returns>
-        public static async Task<PatientSummary> CreatePatientAsync(string testClassName)
+        [AssemblyCleanup()]
+        public static async Task AssemblyCleanup()
         {
-            var workspaceItem = await _proKnow.Workspaces.ResolveAsync(testClassName);
-            await _proKnow.Patients.CreateAsync(workspaceItem.Id, testClassName, testClassName);
-            return await _proKnow.Patients.FindAsync(workspaceItem.Id, t => t.Name == testClassName);
+            // Delete any extraneous SDK test workspaces
+            var workspaces = await _proKnow.Workspaces.QueryAsync();
+            foreach (var workspace in workspaces)
+            {
+                // Make sure workspace name starts with "SDK-" and contains "Test" to protect from accidental deletion of workspaces
+                if (workspace.Name.StartsWith("SDK-") && workspace.Name.Contains("Test"))
+                {
+                    // Turn off protection, if necessary
+                    if (workspace.Protected)
+                    {
+                        workspace.Protected = false;
+                        await workspace.SaveAsync();
+                    }
+                    await _proKnow.Workspaces.DeleteAsync(workspace.Id);
+                }
+            }
         }
 
         /// <summary>
@@ -91,16 +102,6 @@ namespace ProKnow.Test
         }
 
         /// <summary>
-        /// Creates a test workspace asynchronously
-        /// </summary>
-        /// <param name="testClassName">The test class name</param>
-        /// <returns>The created workspace item</returns>
-        public static async Task<WorkspaceItem> CreateWorkspaceAsync(string testClassName)
-        {
-            return await _proKnow.Workspaces.CreateAsync(testClassName.ToLower(), testClassName, false);
-        }
-
-        /// <summary>
         /// Creates a test workspace asynchronously with name SDK-{testClassName}-{testNumber}
         /// </summary>
         /// <param name="testClassName">The test class name</param>
@@ -140,21 +141,6 @@ namespace ProKnow.Test
         }
 
         /// <summary>
-        /// Deletes a test custom metric asynchronously
-        /// </summary>
-        /// <param name="customMetric">The ProKnow ID or name of the custom metric</param>
-        public static async Task DeleteCustomMetricAsync(string customMetric)
-        {
-            // If the custom metric exists
-            var customMetricItem = await _proKnow.CustomMetrics.ResolveAsync(customMetric);
-            if (customMetricItem != null)
-            {
-                // Request the deletion
-                await _proKnow.CustomMetrics.DeleteAsync(customMetricItem.Id);
-            }
-        }
-
-        /// <summary>
         /// Deletes all of the custom metrics for a test
         /// </summary>
         /// <param name="testClassName">The test class name</param>
@@ -187,22 +173,6 @@ namespace ProKnow.Test
         }
 
         /// <summary>
-        /// Deletes a test workspace asynchronously
-        /// </summary>
-        /// <param name="testClassName">The test class name</param>
-        public static async Task DeleteWorkspaceAsync(string testClassName)
-        {
-            // If the workspace exists
-            IList<WorkspaceItem> workspaces = await _proKnow.Workspaces.QueryAsync();
-            var workspaceItem = workspaces.FirstOrDefault(w => w.Name == testClassName);
-            if (workspaceItem != null)
-            {
-                // Request the deletion
-                await _proKnow.Workspaces.DeleteAsync(workspaceItem.Id);
-            }
-        }
-
-        /// <summary>
         /// Deletes all workspaces for a test asynchronously
         /// </summary>
         /// <param name="testClassName">The test class name</param>
@@ -211,8 +181,8 @@ namespace ProKnow.Test
             var workspaces = await _proKnow.Workspaces.QueryAsync();
             foreach (var workspace in workspaces)
             {
-                // Include "SDK" to protect from accidental deletion of workspaces
-                if (workspace.Name.Contains("SDK") && workspace.Name.Contains(testClassName))
+                // Make sure workspace name starts with "SDK-" and contains test class name to protect from accidental deletion of workspaces
+                if (workspace.Name.StartsWith("SDK-") && workspace.Name.Contains(testClassName))
                 {
                     // Turn off protection, if necessary
                     if (workspace.Protected)

--- a/proknow-sdk-test/UploadTest/UploadBatchTest.cs
+++ b/proknow-sdk-test/UploadTest/UploadBatchTest.cs
@@ -11,7 +11,7 @@ namespace ProKnow.Upload.Test
     [TestClass]
     public class UploadBatchTest
     {
-        private static readonly string _patientMrnAndName = "SDK-UploadBatchTest";
+        private static readonly string _testClassName = nameof(UploadBatchTest);
         private static readonly ProKnowApi _proKnow = TestSettings.ProKnow;
 
         [ClassInitialize]
@@ -19,15 +19,15 @@ namespace ProKnow.Upload.Test
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test workspaces, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
         }
 
         [ClassCleanup]
         public static async Task ClassCleanup()
         {
             // Delete test workspaces
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            await TestHelper.DeleteWorkspacesAsync(_testClassName);
         }
 
         [TestMethod]
@@ -36,7 +36,7 @@ namespace ProKnow.Upload.Test
             var testNumber = 1;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Upload test data
             var mrUploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Sro", "mr.dcm");
@@ -84,7 +84,7 @@ namespace ProKnow.Upload.Test
             var testNumber = 2;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Upload test data
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Sro", "mr.dcm");
@@ -114,7 +114,7 @@ namespace ProKnow.Upload.Test
             var testNumber = 3;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Upload test data
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Sro", "reg.dcm");

--- a/proknow-sdk-test/UploadTest/UploadEntitySummaryTest.cs
+++ b/proknow-sdk-test/UploadTest/UploadEntitySummaryTest.cs
@@ -10,7 +10,7 @@ namespace ProKnow.Upload.Test
     [TestClass]
     public class UploadEntitySummaryTest
     {
-        private static readonly string _patientMrnAndName = "SDK-UploadEntitySummaryTest";
+        private static readonly string _testClassName = nameof(UploadEntitySummaryTest);
         private static readonly ProKnowApi _proKnow = TestSettings.ProKnow;
 
         [ClassInitialize]
@@ -18,15 +18,15 @@ namespace ProKnow.Upload.Test
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test workspace, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
         }
 
         [ClassCleanup]
         public static async Task ClassCleanup()
         {
             // Delete test workspaces
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            await TestHelper.DeleteWorkspacesAsync(_testClassName);
         }
 
         [TestMethod]
@@ -35,7 +35,7 @@ namespace ProKnow.Upload.Test
             var testNumber = 1;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Upload test data
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Sro", "ct.dcm");

--- a/proknow-sdk-test/UploadTest/UploadPatientSummaryTest.cs
+++ b/proknow-sdk-test/UploadTest/UploadPatientSummaryTest.cs
@@ -9,7 +9,7 @@ namespace ProKnow.Upload.Test
     [TestClass]
     public class UploadPatientSummaryTest
     {
-        private static readonly string _patientMrnAndName = "SDK-UploadPatientSummaryTest";
+        private static readonly string _testClassName = nameof(UploadPatientSummaryTest);
         private static readonly ProKnowApi _proKnow = TestSettings.ProKnow;
 
         [ClassInitialize]
@@ -17,15 +17,15 @@ namespace ProKnow.Upload.Test
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test workspaces, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
         }
 
         [ClassCleanup]
         public static async Task ClassCleanup()
         {
             // Delete test workspaces
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            await TestHelper.DeleteWorkspacesAsync(_testClassName);
         }
 
         [TestMethod]
@@ -34,7 +34,7 @@ namespace ProKnow.Upload.Test
             var testNumber = 1;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Upload test data
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Sro", "ct.dcm");

--- a/proknow-sdk-test/UploadTest/UploadSroSummaryTest.cs
+++ b/proknow-sdk-test/UploadTest/UploadSroSummaryTest.cs
@@ -10,7 +10,7 @@ namespace ProKnow.Upload.Test
     [TestClass]
     public class UploadSroSummaryTest
     {
-        private static readonly string _patientMrnAndName = "SDK-UploadSroSummaryTest";
+        private static readonly string _testClassName = nameof(UploadSroSummaryTest);
         private static readonly ProKnowApi _proKnow = TestSettings.ProKnow;
 
         [ClassInitialize]
@@ -18,15 +18,15 @@ namespace ProKnow.Upload.Test
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test workspace, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
         }
 
         [ClassCleanup]
         public static async Task ClassCleanup()
         {
             // Delete test workspaces
-            await TestHelper.DeleteWorkspacesAsync(_patientMrnAndName);
+            await TestHelper.DeleteWorkspacesAsync(_testClassName);
         }
 
         [TestMethod]
@@ -35,7 +35,7 @@ namespace ProKnow.Upload.Test
             var testNumber = 1;
 
             // Create a test workspace
-            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_patientMrnAndName, testNumber);
+            var workspaceItem = await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
 
             // Upload test data
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Sro");
@@ -54,7 +54,7 @@ namespace ProKnow.Upload.Test
             // Get the full representation of the patient, entities, and SRO
             var ctImageSetItem = await uploadCtEntitySummary.GetAsync();
             var mrImageSetItem = await uploadMrEntitySummary.GetAsync();
-            var sroItem = await uploadSroSummary.GetAsync() as SroItem;
+            var sroItem = await uploadSroSummary.GetAsync();
 
             // Verify the contents
             Assert.AreEqual(workspaceItem.Id, sroItem.WorkspaceId);

--- a/proknow-sdk-test/UploadTest/UploadsTest.cs
+++ b/proknow-sdk-test/UploadTest/UploadsTest.cs
@@ -11,17 +11,16 @@ namespace ProKnow.Upload.Test
     [TestClass]
     public class UploadsTest
     {
-        private static readonly string _testClassName = "SDK-UploadsTest";
+        private static readonly string _testClassName = nameof(UploadsTest);
         private static readonly ProKnowApi _proKnow = TestSettings.ProKnow;
-        private static readonly Uploads _uploads = _proKnow.Uploads;
 
         [ClassInitialize]
 #pragma warning disable IDE0060 // Remove unused parameter
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test workspaces, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_testClassName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
         }
 
         [ClassCleanup]
@@ -48,7 +47,7 @@ namespace ProKnow.Upload.Test
             {
                 Patient = new PatientCreateSchema { Mrn = patientItem.Mrn, Name = patientItem.Name }
             };
-            var uploadBatch = await _uploads.UploadAsync(workspaceItem.Id, uploadPath, overrides);
+            await _proKnow.Uploads.UploadAsync(workspaceItem.Id, uploadPath, overrides);
 
             // Wait until uploaded test file has processed
             while (true)
@@ -58,7 +57,7 @@ namespace ProKnow.Upload.Test
                 if (entitySummaries.Count == 1 && entitySummaries[0].Status == "completed")
                 {
                     // Make sure the uploaded data is the same
-                    Assert.AreEqual(entitySummaries[0].Uid, "2.16.840.1.114337.1.1.1535997926.0");
+                    Assert.AreEqual("2.16.840.1.114337.1.1.1535997926.0", entitySummaries[0].Uid);
 
                     break;
                 }
@@ -82,7 +81,7 @@ namespace ProKnow.Upload.Test
             {
                 Patient = new PatientCreateSchema { Mrn = patientItem.Mrn, Name = patientItem.Name }
             };
-            var uploadBatch = await _uploads.UploadAsync(workspaceItem.Id, uploadPath, overrides);
+            await _proKnow.Uploads.UploadAsync(workspaceItem.Id, uploadPath, overrides);
 
             // Wait until uploaded test files have processed
             while (true)
@@ -120,7 +119,7 @@ namespace ProKnow.Upload.Test
             {
                 Patient = new PatientCreateSchema { Mrn = patientItem.Mrn, Name = patientItem.Name }
             };
-            var uploadBatch = await _uploads.UploadAsync(workspaceItem.Id, uploadPaths, overrides);
+            await _proKnow.Uploads.UploadAsync(workspaceItem.Id, uploadPaths, overrides);
 
             // Verify test folder and test file were uploaded (may have to wait for files to be processed)
             while (true)

--- a/proknow-sdk-test/UploadTest/UploadsTest.cs
+++ b/proknow-sdk-test/UploadTest/UploadsTest.cs
@@ -49,19 +49,11 @@ namespace ProKnow.Upload.Test
             };
             await _proKnow.Uploads.UploadAsync(workspaceItem.Id, uploadPath, overrides);
 
-            // Wait until uploaded test file has processed
-            while (true)
-            {
-                await patientItem.RefreshAsync();
-                var entitySummaries = patientItem.FindEntities(t => true);
-                if (entitySummaries.Count == 1 && entitySummaries[0].Status == "completed")
-                {
-                    // Make sure the uploaded data is the same
-                    Assert.AreEqual("2.16.840.1.114337.1.1.1535997926.0", entitySummaries[0].Uid);
-
-                    break;
-                }
-            }
+            // Verify file was uploaded
+            await patientItem.RefreshAsync();
+            var entitySummaries = patientItem.FindEntities(t => true);
+            Assert.AreEqual(1, entitySummaries.Count);
+            Assert.AreEqual("2.16.840.1.114337.1.1.1535997926.0", entitySummaries[0].Uid);
         }
 
         [TestMethod]
@@ -83,21 +75,12 @@ namespace ProKnow.Upload.Test
             };
             await _proKnow.Uploads.UploadAsync(workspaceItem.Id, uploadPath, overrides);
 
-            // Wait until uploaded test files have processed
-            while (true)
-            {
-                await patientItem.RefreshAsync();
-                var entitySummaries = patientItem.FindEntities(t => true);
-                if (entitySummaries.Count == 1 && entitySummaries[0].Status == "completed")
-                {
-                    // Make sure the uploaded data is the same
-                    var entityItem = await entitySummaries[0].GetAsync() as ImageSetItem;
-                    if (entityItem.Data.Images.Count == 5)
-                    {
-                        break;
-                    }
-                }
-            }
+            // Verify files were uploaded
+            await patientItem.RefreshAsync();
+            var entitySummaries = patientItem.FindEntities(t => true);
+            Assert.AreEqual(1, entitySummaries.Count);
+            var entityItem = await entitySummaries[0].GetAsync() as ImageSetItem;
+            Assert.AreEqual(5, entityItem.Data.Images.Count);
         }
 
         [TestMethod]
@@ -121,21 +104,13 @@ namespace ProKnow.Upload.Test
             };
             await _proKnow.Uploads.UploadAsync(workspaceItem.Id, uploadPaths, overrides);
 
-            // Verify test folder and test file were uploaded (may have to wait for files to be processed)
-            while (true)
-            {
-                await patientItem.RefreshAsync();
-                var entitySummaries = patientItem.FindEntities(t => true);
-                if (entitySummaries.Count == 2 && entitySummaries[0].Status == "completed" && entitySummaries[1].Status == "completed")
-                {
-                    var imageSetSummary = patientItem.FindEntities(t => t.Type == "image_set")[0];
-                    var entityItem = await imageSetSummary.GetAsync() as ImageSetItem;
-                    if (entityItem.Data.Images.Count == 5)
-                    {
-                        break;
-                    }
-                }
-            }
+            // Verify test folder and test file were uploaded
+            await patientItem.RefreshAsync();
+            var entitySummaries = patientItem.FindEntities(t => true);
+            Assert.AreEqual(2, entitySummaries.Count);
+            var imageSetSummary = patientItem.FindEntities(t => t.Type == "image_set")[0];
+            var entityItem = await imageSetSummary.GetAsync() as ImageSetItem;
+            Assert.AreEqual(5, entityItem.Data.Images.Count);
         }
     }
 }

--- a/proknow-sdk-test/WorkspaceItemTest.cs
+++ b/proknow-sdk-test/WorkspaceItemTest.cs
@@ -14,8 +14,8 @@ namespace ProKnow.Test
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test workspaces, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_testClassName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
         }
 
         [ClassCleanup]

--- a/proknow-sdk-test/WorkspacesTest.cs
+++ b/proknow-sdk-test/WorkspacesTest.cs
@@ -16,8 +16,8 @@ namespace ProKnow.Test
         public static async Task ClassInitialize(TestContext testContext)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            // Delete test workspaces, if necessary
-            await TestHelper.DeleteWorkspacesAsync(_testClassName);
+            // Cleanup from previous test stoppage or failure, if necessary
+            await ClassCleanup();
         }
 
         [ClassCleanup]

--- a/proknow-sdk/Upload/UploadBatch.cs
+++ b/proknow-sdk/Upload/UploadBatch.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ProKnow.Exceptions;
+using System;
 using System.Collections.Generic;
 
 namespace ProKnow.Upload
@@ -86,8 +87,8 @@ namespace ProKnow.Upload
         /// using System.Threading.Tasks;
         ///
         /// var pk = new ProKnowApi("https://example.proknow.com", "credentials.json");
-        /// var uploadBatch = await pk.Uploads.UploadAsync("Upload Test", "DICOM");
-        /// var path = Path.GetFullPath(Path.Join("DICOM", "plan.dcm"));
+        /// var uploadBatch = await pk.Uploads.UploadAsync("Upload Test", "./DICOM");
+        /// var path = Path.GetFullPath(Path.Join("./DICOM", "plan.dcm"));
         /// var uploadPatientSummary = uploadBatch.FindPatient(path);
         /// </code>
         /// </example>
@@ -100,9 +101,9 @@ namespace ProKnow.Upload
                 {
                     return _patientLookup[uploadStatusResult.Patient.Id];
                 }
-                throw new ApplicationException($"The upload for '{path}' is not complete.");
+                throw new InvalidOperationError($"The upload for '{path}' is not complete.");
             }
-            throw new ApplicationException($"The upload for '{path}' was not found in the batch.");
+            throw new InvalidOperationError($"The upload for '{path}' was not found in the batch.");
         }
 
         /// <summary>
@@ -117,8 +118,8 @@ namespace ProKnow.Upload
         /// using System.Threading.Tasks;
         ///
         /// var pk = new ProKnowApi("https://example.proknow.com", "credentials.json");
-        /// var uploadBatch = await pk.Uploads.UploadAsync("Upload Test", "DICOM");
-        /// var path = Path.GetFullPath(Path.Join("DICOM", "plan.dcm"));
+        /// var uploadBatch = await pk.Uploads.UploadAsync("Upload Test", "./DICOM");
+        /// var path = Path.GetFullPath(Path.Join("./DICOM", "plan.dcm"));
         /// var uploadEntitySummary = uploadBatch.FindEntity(path);
         /// </code>
         /// </example>
@@ -133,11 +134,11 @@ namespace ProKnow.Upload
                     {
                         return _entityLookup[uploadStatusResult.Entity.Id];
                     }
-                    throw new ApplicationException($"The uploaded file '{path}' is not an entity.");
+                    throw new InvalidOperationError($"The uploaded file '{path}' is not an entity.");
                 }
-                throw new ApplicationException($"The upload for '{path}' is not complete.");
+                throw new InvalidOperationError($"The upload for '{path}' is not complete.");
             }
-            throw new ApplicationException($"The upload for '{path}' was not found in the batch.");
+            throw new InvalidOperationError($"The upload for '{path}' was not found in the batch.");
         }
 
         /// <summary>
@@ -168,11 +169,11 @@ namespace ProKnow.Upload
                     {
                         return _sroLookup[uploadStatusResult.Sro.Id];
                     }
-                    throw new ApplicationException($"The uploaded file '{path}' is not a spatial registration object.");
+                    throw new InvalidOperationError($"The uploaded file '{path}' is not a spatial registration object.");
                 }
-                throw new ApplicationException($"The upload for '{path}' is not complete.");
+                throw new InvalidOperationError($"The upload for '{path}' is not complete.");
             }
-            throw new ApplicationException($"The upload for '{path}' was not found in the batch.");
+            throw new InvalidOperationError($"The upload for '{path}' was not found in the batch.");
         }
     }
 }

--- a/proknow-sdk/Upload/UploadEntitySummary.cs
+++ b/proknow-sdk/Upload/UploadEntitySummary.cs
@@ -84,7 +84,7 @@ namespace ProKnow.Upload
         /// using System.Threading.Tasks;
         ///
         /// var pk = new ProKnowApi("https://example.proknow.com", "credentials.json");
-        /// var uploadBatch = await pk.Uploads.UploadAsync("Upload Test", "DICOM");
+        /// var uploadBatch = await pk.Uploads.UploadAsync("Upload Test", "./DICOM");
         /// var entityItems = new List&lt;EntityItem&gt;();
         /// foreach (var patient in uploadBatch.Patients)
         /// {

--- a/proknow-sdk/Upload/UploadPatientSummary.cs
+++ b/proknow-sdk/Upload/UploadPatientSummary.cs
@@ -76,7 +76,7 @@ namespace ProKnow.Upload
         /// using System.Threading.Tasks;
         ///
         /// var pk = new ProKnowApi("https://example.proknow.com", "credentials.json");
-        /// var uploadBatch = await pk.Uploads.UploadAsync("Upload Test", "DICOM");
+        /// var uploadBatch = await pk.Uploads.UploadAsync("Upload Test", "./DICOM");
         /// var patientItems = await Task.WhenAll(uploadBatch.Patients.Select(async p => await p.GetAsync()));
         /// </code>
         /// </example>

--- a/proknow-sdk/Upload/UploadSroSummary.cs
+++ b/proknow-sdk/Upload/UploadSroSummary.cs
@@ -77,7 +77,7 @@ namespace ProKnow.Upload
         /// using System.Threading.Tasks;
         ///
         /// var pk = new ProKnowApi("https://example.proknow.com", "credentials.json");
-        /// var uploadBatch = await pk.Uploads.UploadAsync("Upload Test", "DICOM");
+        /// var uploadBatch = await pk.Uploads.UploadAsync("Upload Test", "./DICOM");
         /// var sroItems = new List&lt;SroItem&gt;();
         /// foreach (var patient in uploadBatch.Patients)
         /// {

--- a/proknow-sdk/Upload/Uploads.cs
+++ b/proknow-sdk/Upload/Uploads.cs
@@ -310,26 +310,22 @@ namespace ProKnow.Upload
                     // Update the mapping of upload ID to status result
                     uploadIdToStatusResultsMap[uploadStatusResult.Id] = uploadStatusResult;
 
-                    // If this upload was not previously resolved
-                    if (unresolvedUploads.Contains(uploadStatusResult.Id))
+                    // If this upload was not previously resolved and has reached terminal status
+                    if (unresolvedUploads.Contains(uploadStatusResult.Id) && _terminalStatuses.Contains(uploadStatusResult.Status))
                     {
-                        // If this upload has reached terminal status
-                        if (_terminalStatuses.Contains(uploadStatusResult.Status))
-                        {
-                            // Indicate this upload is resolved
-                            unresolvedUploads.Remove(uploadStatusResult.Id);
+                        // Indicate this upload is resolved
+                        unresolvedUploads.Remove(uploadStatusResult.Id);
 
-                            // Update the query parameters to the latest upload to reach terminal status
-                            if (uploadStatusResult.UpdatedAt > lastUpdatedAt)
+                        // Update the query parameters to the latest upload to reach terminal status
+                        if (uploadStatusResult.UpdatedAt > lastUpdatedAt)
+                        {
+                            if (queryParameters == null)
                             {
-                                if (queryParameters == null)
-                                {
-                                    queryParameters = new Dictionary<string, object>();
-                                }
-                                lastUpdatedAt = uploadStatusResult.UpdatedAt;
-                                queryParameters["updated"] = lastUpdatedAt;
-                                queryParameters["after"] = uploadStatusResult.Id;
+                                queryParameters = new Dictionary<string, object>();
                             }
+                            lastUpdatedAt = uploadStatusResult.UpdatedAt;
+                            queryParameters["updated"] = lastUpdatedAt;
+                            queryParameters["after"] = uploadStatusResult.Id;
                         }
                     }
                 }

--- a/proknow-sdk/Upload/Uploads.cs
+++ b/proknow-sdk/Upload/Uploads.cs
@@ -52,7 +52,7 @@ namespace ProKnow.Upload
         /// using System.Threading.Tasks;
         ///
         /// var pk = new ProKnowApi("https://example.proknow.com", "credentials.json");
-        /// await pk.Uploads.UploadAsync("Upload Test", "DICOM");
+        /// await pk.Uploads.UploadAsync("Upload Test", "./DICOM");
         /// </code>
         /// </example>
         public async Task<UploadBatch> UploadAsync(string workspace, string path, UploadFileOverrides overrides = null,

--- a/proknow-sdk/proknow-sdk.csproj
+++ b/proknow-sdk/proknow-sdk.csproj
@@ -8,7 +8,7 @@
     <Company>Elekta</Company>
     <Product>ProKnow</Product>
     <PackageId>ProKnow</PackageId>
-    <Version>0.0.21</Version>
+    <Version>0.0.22</Version>
     <Authors>ProKnow</Authors>
     <Description>ProKnow.NET SDK is a .NET Standard client and a portable class library for ProKnow</Description>
     <RepositoryUrl>https://github.com/proknow/proknow-sdk-dotnet</RepositoryUrl>


### PR DESCRIPTION
- Refactor and fix possible threading issues in unit tests
- Ensure that a structure set draft lock renewer timer does not fire after the edit lock has been removed
- Replace use of generic ApplicationException with more specific InvalidOperationError
