### PR TITLE
Get dose slice data

### DIFF
--- a/docs/releaseHistory.md
+++ b/docs/releaseHistory.md
@@ -4,6 +4,14 @@
 
 All releases in the v0.x.x series are subject to breaking changes from one version to another.  After the release of v1.0.0, this project will be subject to [semantic versioning](http://semver.org/).
 
+## v0.0.24
+
+*New Features and Enhancements*
+- Add GetSliceDataAsync method to DoseItem class to retrieve voxel data (DoseSlice)
+- Add DoseData property to DoseItem class to provide dose properties
+- Modify GetImageDataAsync method of ImageSetItem class to return UInt16[] instead of byte[]
+- Modify Position property of ImageSetItem to be mm instead of 1/1000 mm
+
 ## v0.0.23
 
 *New Features and Enhancements*

--- a/proknow-sdk-test/PatientTest/EntitiesTest/DoseItemTest.cs
+++ b/proknow-sdk-test/PatientTest/EntitiesTest/DoseItemTest.cs
@@ -158,18 +158,18 @@ namespace ProKnow.Patient.Entities.Test
             var doseItem = await entitySummaries[0].GetAsync() as DoseItem;
 
             // Get the data for this first dose slice
-            var pixelData = await doseItem.GetSliceDataAsync(0);
+            var voxelData = await doseItem.GetSliceDataAsync(0);
 
             // Verify the data
-            Assert.AreEqual(doseItem.Data.ResolutionX * doseItem.Data.ResolutionZ, pixelData.Length);
+            Assert.AreEqual(doseItem.Data.ResolutionX * doseItem.Data.ResolutionZ, voxelData.Length);
             var intercept = doseItem.Data.PixelIntercept;
             var slope = doseItem.Data.PixelSlope;
             var tolerance = 0.5 * slope; // half of a pixel
-            Assert.AreEqual(5.0873445503321e-06 * uint.Parse("00009901", System.Globalization.NumberStyles.AllowHexSpecifier), intercept + slope * pixelData[83], tolerance);
-            Assert.AreEqual(5.0873445503321e-06 * uint.Parse("00009901", System.Globalization.NumberStyles.AllowHexSpecifier), intercept + slope * pixelData[84], tolerance);
-            Assert.AreEqual(5.0873445503321e-06 * uint.Parse("00008801", System.Globalization.NumberStyles.AllowHexSpecifier), intercept + slope * pixelData[85], tolerance);
-            Assert.AreEqual(5.0873445503321e-06 * uint.Parse("00007b00", System.Globalization.NumberStyles.AllowHexSpecifier), intercept + slope * pixelData[86], tolerance);
-            Assert.AreEqual(5.0873445503321e-06 * uint.Parse("0000b601", System.Globalization.NumberStyles.AllowHexSpecifier), intercept + slope * pixelData[87], tolerance);
+            Assert.AreEqual(5.0873445503321e-06 * uint.Parse("00009901", System.Globalization.NumberStyles.AllowHexSpecifier), intercept + slope * voxelData[83], tolerance);
+            Assert.AreEqual(5.0873445503321e-06 * uint.Parse("00009901", System.Globalization.NumberStyles.AllowHexSpecifier), intercept + slope * voxelData[84], tolerance);
+            Assert.AreEqual(5.0873445503321e-06 * uint.Parse("00008801", System.Globalization.NumberStyles.AllowHexSpecifier), intercept + slope * voxelData[85], tolerance);
+            Assert.AreEqual(5.0873445503321e-06 * uint.Parse("00007b00", System.Globalization.NumberStyles.AllowHexSpecifier), intercept + slope * voxelData[86], tolerance);
+            Assert.AreEqual(5.0873445503321e-06 * uint.Parse("0000b601", System.Globalization.NumberStyles.AllowHexSpecifier), intercept + slope * voxelData[87], tolerance);
         }
     }
 }

--- a/proknow-sdk-test/PatientTest/EntitiesTest/DoseItemTest.cs
+++ b/proknow-sdk-test/PatientTest/EntitiesTest/DoseItemTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ProKnow.Test;
+using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -141,6 +142,34 @@ namespace ProKnow.Patient.Entities.Test
             // Compare it to the uploaded one
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Becker^Matthew", "RD.dcm");
             Assert.IsTrue(TestHelper.FileEquals(uploadPath, actualDownloadPath));
+        }
+
+        [TestMethod]
+        public async Task GetSliceDataAsyncTest()
+        {
+            var testNumber = 5;
+
+            // Create a test workspace
+            await TestHelper.CreateWorkspaceAsync(_testClassName, testNumber);
+
+            // Create a test patient with a dose
+            var patientItem = await TestHelper.CreatePatientAsync(_testClassName, testNumber, Path.Combine("Becker^Matthew", "RD.dcm"), 1);
+            var entitySummaries = patientItem.FindEntities(e => e.Type == "dose");
+            var doseItem = await entitySummaries[0].GetAsync() as DoseItem;
+
+            // Get the data for this first dose slice
+            var pixelData = await doseItem.GetSliceDataAsync(0);
+
+            // Verify the data
+            Assert.AreEqual(doseItem.Data.ResolutionX * doseItem.Data.ResolutionZ, pixelData.Length);
+            var intercept = doseItem.Data.PixelIntercept;
+            var slope = doseItem.Data.PixelSlope;
+            var tolerance = 0.5 * slope; // half of a pixel
+            Assert.AreEqual(5.0873445503321e-06 * uint.Parse("00009901", System.Globalization.NumberStyles.AllowHexSpecifier), intercept + slope * pixelData[83], tolerance);
+            Assert.AreEqual(5.0873445503321e-06 * uint.Parse("00009901", System.Globalization.NumberStyles.AllowHexSpecifier), intercept + slope * pixelData[84], tolerance);
+            Assert.AreEqual(5.0873445503321e-06 * uint.Parse("00008801", System.Globalization.NumberStyles.AllowHexSpecifier), intercept + slope * pixelData[85], tolerance);
+            Assert.AreEqual(5.0873445503321e-06 * uint.Parse("00007b00", System.Globalization.NumberStyles.AllowHexSpecifier), intercept + slope * pixelData[86], tolerance);
+            Assert.AreEqual(5.0873445503321e-06 * uint.Parse("0000b601", System.Globalization.NumberStyles.AllowHexSpecifier), intercept + slope * pixelData[87], tolerance);
         }
     }
 }

--- a/proknow-sdk-test/PatientTest/EntitiesTest/ImageSetItemTest.cs
+++ b/proknow-sdk-test/PatientTest/EntitiesTest/ImageSetItemTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ProKnow.Test;
+using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -72,21 +73,19 @@ namespace ProKnow.Patient.Entities.Test
             var entitySummaries = patientItem.FindEntities(e => e.Type == "image_set");
             var imageSetItem = await entitySummaries[0].GetAsync() as ImageSetItem;
 
-            // Get the data for the first image
-            var bytes = await imageSetItem.GetImageDataAsync(0);
+            // Get the data for the first image (CT.5.dcm)
+            var imageData = await imageSetItem.GetImageDataAsync(0);
 
             // Verify the data
-            Assert.AreEqual(512 * 512 * 2, bytes.Length);
-            Assert.AreEqual(32, bytes[401]);
-            Assert.AreEqual(0, bytes[402]);
-            Assert.AreEqual(41, bytes[403]);
-            Assert.AreEqual(0, bytes[404]);
-            Assert.AreEqual(46, bytes[405]);
-            Assert.AreEqual(0, bytes[406]);
-            Assert.AreEqual(47, bytes[407]);
-            Assert.AreEqual(00, bytes[408]);
-            Assert.AreEqual(48, bytes[409]);
-            Assert.AreEqual(0, bytes[410]);
+            Assert.AreEqual(imageSetItem.Data.NumberOfRows * imageSetItem.Data.NumberOfColumns, imageData.Length);
+            var intercept = imageSetItem.Data.Images[0].RescaleIntercept;
+            var slope = imageSetItem.Data.Images[0].RescaleSlope;
+            var tolerance = 0.5 * slope; // half of a pixel
+            Assert.AreEqual(-1024 + 1.001 * ushort.Parse("0029", System.Globalization.NumberStyles.AllowHexSpecifier), intercept + slope * imageData[201], tolerance);
+            Assert.AreEqual(-1024 + 1.001 * ushort.Parse("002e", System.Globalization.NumberStyles.AllowHexSpecifier), intercept + slope * imageData[202], tolerance);
+            Assert.AreEqual(-1024 + 1.001 * ushort.Parse("002f", System.Globalization.NumberStyles.AllowHexSpecifier), intercept + slope * imageData[203], tolerance);
+            Assert.AreEqual(-1024 + 1.001 * ushort.Parse("0030", System.Globalization.NumberStyles.AllowHexSpecifier), intercept + slope * imageData[204], tolerance);
+            Assert.AreEqual(-1024 + 1.001 * ushort.Parse("0026", System.Globalization.NumberStyles.AllowHexSpecifier), intercept + slope * imageData[205], tolerance);
         }
     }
 }

--- a/proknow-sdk/Patient/Entities/DoseData.cs
+++ b/proknow-sdk/Patient/Entities/DoseData.cs
@@ -1,0 +1,162 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace ProKnow.Patient.Entities
+{
+    /// <summary>
+    /// A container for the dose entity item data
+    /// </summary>
+    public class DoseData
+    {
+        /// <summary>
+        /// The minimum IEC couch x position in mm
+        /// </summary>
+        [JsonPropertyName("min_x")]
+        public double MinX { get; set; }
+
+        /// <summary>
+        /// The minimum IEC couch y position in mm
+        /// </summary>
+        [JsonPropertyName("min_y")]
+        public double MinY { get; set; }
+
+        /// <summary>
+        /// The minimum IEC couch z position in mm
+        /// </summary>
+        [JsonPropertyName("min_z")]
+        public double MinZ { get; set; }
+
+        /// <summary>
+        /// The maximum IEC couch x position in mm
+        /// </summary>
+        [JsonPropertyName("max_x")]
+        public double MaxX { get; set; }
+
+        /// <summary>
+        /// The maximum IEC couch y position in mm
+        /// </summary>
+        [JsonPropertyName("max_y")]
+        public double MaxY { get; set; }
+
+        /// <summary>
+        /// The maximum IEC couch z position in mm
+        /// </summary>
+        [JsonPropertyName("max_z")]
+        public double MaxZ { get; set; }
+
+        /// <summary>
+        /// The number of voxels in the IEC x direction
+        /// </summary>
+        [JsonPropertyName("resolution_x")]
+        public int ResolutionX { get; set; }
+
+        /// <summary>
+        /// The number of voxels in the IEC y direction
+        /// </summary>
+        [JsonPropertyName("resolution_y")]
+        public int ResolutionY { get; set; }
+
+        /// <summary>
+        /// The number of voxels in the IEC z direction
+        /// </summary>
+        [JsonPropertyName("resolution_z")]
+        public int ResolutionZ { get; set; }
+
+        /// <summary>
+        /// The voxel spacing in the IEC x direction in mm
+        /// </summary>
+        [JsonPropertyName("spacing_x")]
+        public double SpacingX { get; set; }
+
+        /// <summary>
+        /// The (average) voxel spacing in the IEC y direction in mm
+        /// </summary>
+        [JsonPropertyName("spacing_y")]
+        public double SpacingY { get; set; }
+
+        /// <summary>
+        /// The voxel spacing in the IEC z direction in mm
+        /// </summary>
+        [JsonPropertyName("spacing_z")]
+        public double SpacingZ { get; set; }
+
+        /// <summary>
+        /// The size of the dose volume in the IEC x direction in mm
+        /// </summary>
+        [JsonPropertyName("size_x")]
+        public double SizeX { get; set; }
+
+        /// <summary>
+        /// The size of the dose volume in the IEC y direction in mm
+        /// </summary>
+        [JsonPropertyName("size_y")]
+        public double SizeY { get; set; }
+
+        /// <summary>
+        /// The size of the dose volume in the IEC z direction in mm
+        /// </summary>
+        [JsonPropertyName("size_z")]
+        public double SizeZ { get; set; }
+
+        /// <summary>
+        /// True if the dose slabs in the IEC y direction are uniformly spaced
+        /// </summary>
+        [JsonPropertyName("uniform_y")]
+        public bool IsUniformY { get; set; }
+
+        /// <summary>
+        /// The intercept of the linear transformation from stored voxel value to output units
+        /// </summary>
+        [JsonPropertyName("pixel_intercept")]
+        public double PixelIntercept { get; set; }
+
+        /// <summary>
+        /// The slope of the linear transformation from stored voxel value to output units
+        /// </summary>
+        [JsonPropertyName("pixel_slope")]
+        public double PixelSlope { get; set; }
+
+        /// <summary>
+        /// The minimum dose value
+        /// </summary>
+        [JsonPropertyName("min_value")]
+        public double MinValue { get; set; }
+
+        /// <summary>
+        /// The maximum dose value
+        /// </summary>
+        [JsonPropertyName("max_value")]
+        public double MaxValue { get; set; }
+
+        /// <summary>
+        /// The summation type ("PLAN", "MULTI_PLAN", "FRACTION", "BEAM", "BRACHY", "FRACTION_SESSION", "BEAM_SESSION",
+        /// "BRACHY_SESSION", "CONTROL_POINT", or "RECORD")
+        /// </summary>
+        [JsonPropertyName("summation_type")]
+        public string SummationType { get; set; }
+
+        /// <summary>
+        /// The dose type ("PHYSICAL", "EFFECTIVE", or "ERROR")
+        /// </summary>
+        [JsonPropertyName("type")]
+        public string DoseType { get; set; }
+
+        /// <summary>
+        /// The dose units ("GY" or "RELATIVE")
+        /// </summary>
+        [JsonPropertyName("units")]
+        public string DoseUnits { get; set; }
+
+        /// <summary>
+        /// The dose slices in the IEC y direction
+        /// </summary>
+        [JsonPropertyName("slices")]
+        public IList<DoseSlice> Slices { get; set; }
+
+        /// <summary>
+        /// Properties encountered during deserialization without matching members
+        /// </summary>
+        [JsonExtensionData]
+        public Dictionary<string, object> ExtensionData { get; set; }
+    }
+}

--- a/proknow-sdk/Patient/Entities/DoseItem.cs
+++ b/proknow-sdk/Patient/Entities/DoseItem.cs
@@ -68,6 +68,7 @@ namespace ProKnow.Patient.Entities
         /// </summary>
         /// <param name="index">The slice index</param>
         /// <returns>The voxel data for the specified slice</returns>
+        //todo--add example
         public async Task<UInt16[]> GetSliceDataAsync(int index)
         {
             var slice = Data.Slices[index];
@@ -83,7 +84,7 @@ namespace ProKnow.Patient.Entities
             var j = 0;
             while (i < bytes.Length)
             {
-                sliceData[j++] = (UInt16)((bytes[i++] << 8) | bytes[i++]);
+                sliceData[j++] = (UInt16)((bytes[i++] << 8) | bytes[i++]); // Convert from network byte order (big endian)
             }
             return sliceData;
         }

--- a/proknow-sdk/Patient/Entities/DoseItem.cs
+++ b/proknow-sdk/Patient/Entities/DoseItem.cs
@@ -64,11 +64,23 @@ namespace ProKnow.Patient.Entities
         }
 
         /// <summary>
-        /// Gets the data for a specified slice asynchronously
+        /// Gets the voxel data for a specified slice asynchronously
         /// </summary>
         /// <param name="index">The slice index</param>
         /// <returns>The voxel data for the specified slice</returns>
-        //todo--add example
+        /// <example>This example shows how to get the voxel data for an image:
+        /// <code>
+        /// using ProKnow;
+        /// using System.Threading.Tasks;
+        ///
+        /// var pk = new ProKnowApi("https://example.proknow.com", "./credentials.json");
+        /// var workspaceItem = await _proKnow.Workspaces.FindAsync(w => w.Name == "Clinical");
+        /// var patientSummary = await _proKnow.Patients.FindAsync(workspaceItem.Id, p => p.Name == "Example");
+        /// var patientItem = await patientSummary.GetAsync();
+        /// var doseItem = patientItem.FindEntities(e => e.Type == "dose")[0];
+        /// var voxelData = await doseItem.GetSliceDataAsync(0);
+        /// </code>
+        /// </example>
         public async Task<UInt16[]> GetSliceDataAsync(int index)
         {
             var slice = Data.Slices[index];

--- a/proknow-sdk/Patient/Entities/DoseSlice.cs
+++ b/proknow-sdk/Patient/Entities/DoseSlice.cs
@@ -1,0 +1,31 @@
+﻿using System.Text.Json.Serialization;
+
+namespace ProKnow.Patient.Entities
+{
+    /// <summary>
+    /// A container for dose slice data
+    /// </summary>
+    public class DoseSlice
+    {
+        /// <summary>
+        /// The slice position in 1/1000 mm
+        /// </summary>
+        [JsonPropertyName("pos")]
+        public int Position { get; set; }
+
+        /// <summary>
+        /// The tag for the slice data in blob storage
+        /// </summary>
+        [JsonPropertyName("tag")]
+        public string Tag { get; set; }
+
+        /// <summary>
+        /// Provides a string representation of this object
+        /// </summary>
+        /// <returns>A string representation of this object</returns>
+        public override string ToString()
+        {
+            return Position.ToString();
+        }
+    }
+}

--- a/proknow-sdk/Patient/Entities/DoseSlice.cs
+++ b/proknow-sdk/Patient/Entities/DoseSlice.cs
@@ -10,6 +10,7 @@ namespace ProKnow.Patient.Entities
         /// <summary>
         /// The slice position in 1/1000 mm
         /// </summary>
+        //todo--[JsonConverter(typeof(CoordinateJsonConverter))]
         [JsonPropertyName("pos")]
         public int Position { get; set; }
 

--- a/proknow-sdk/Patient/Entities/DoseSlice.cs
+++ b/proknow-sdk/Patient/Entities/DoseSlice.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using ProKnow.JsonConverters;
+using System.Text.Json.Serialization;
 
 namespace ProKnow.Patient.Entities
 {
@@ -8,11 +9,11 @@ namespace ProKnow.Patient.Entities
     public class DoseSlice
     {
         /// <summary>
-        /// The slice position in 1/1000 mm
+        /// The slice position in mm
         /// </summary>
-        //todo--[JsonConverter(typeof(CoordinateJsonConverter))]
+        [JsonConverter(typeof(CoordinateJsonConverter))]
         [JsonPropertyName("pos")]
-        public int Position { get; set; }
+        public double Position { get; set; }
 
         /// <summary>
         /// The tag for the slice data in blob storage

--- a/proknow-sdk/Patient/Entities/Image.cs
+++ b/proknow-sdk/Patient/Entities/Image.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using ProKnow.JsonConverters;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace ProKnow.Patient.Entities
@@ -27,10 +28,11 @@ namespace ProKnow.Patient.Entities
         public double RescaleSlope { get; set; }
 
         /// <summary>
-        /// The image position in 1/1000 mm
+        /// The image position in mm
         /// </summary>
+        [JsonConverter(typeof(CoordinateJsonConverter))]
         [JsonPropertyName("pos")]
-        public int Position { get; set; }
+        public double Position { get; set; }
 
         /// <summary>
         /// The IEC X image position in mm
@@ -74,7 +76,7 @@ namespace ProKnow.Patient.Entities
         /// <returns>A string representation of this object</returns>
         public override string ToString()
         {
-            return PositionY.ToString();
+            return Position.ToString();
         }
     }
 }

--- a/proknow-sdk/Patient/Entities/ImageSetItem.cs
+++ b/proknow-sdk/Patient/Entities/ImageSetItem.cs
@@ -64,13 +64,21 @@ namespace ProKnow.Patient.Entities
         /// Gets the pixel data for a specified image asynchronously
         /// </summary>
         /// <param name="index">The index of the image</param>
-        /// <returns>The pixel data as a byte array</returns>
-        public Task<byte[]> GetImageDataAsync(int index)
+        /// <returns>The pixel data for the specified image</returns>
+        public async Task<UInt16[]> GetImageDataAsync(int index)
         {
             var image = Data.Images[index];
             var headerKeyValuePairs = new List<KeyValuePair<string, string>>() {
                 new KeyValuePair<string, string>("ProKnow-Key", Key) };
-            return _proKnow.Requestor.GetBinaryAsync($"/imagesets/{Id}/images/{image.Tag}", headerKeyValuePairs);
+            var bytes = await _proKnow.Requestor.GetBinaryAsync($"/imagesets/{Id}/images/{image.Tag}", headerKeyValuePairs);
+            var imageData = new UInt16[bytes.Length / 2];
+            var i = 0;
+            var j = 0;
+            while (i < bytes.Length)
+            {
+                imageData[j++] = (UInt16)((bytes[i++] << 8) | bytes[i++]);
+            }
+            return imageData;
         }
     }
 }

--- a/proknow-sdk/Patient/Entities/ImageSetItem.cs
+++ b/proknow-sdk/Patient/Entities/ImageSetItem.cs
@@ -65,6 +65,7 @@ namespace ProKnow.Patient.Entities
         /// </summary>
         /// <param name="index">The index of the image</param>
         /// <returns>The pixel data for the specified image</returns>
+        //todo--add example
         public async Task<UInt16[]> GetImageDataAsync(int index)
         {
             var image = Data.Images[index];
@@ -76,7 +77,7 @@ namespace ProKnow.Patient.Entities
             var j = 0;
             while (i < bytes.Length)
             {
-                imageData[j++] = (UInt16)((bytes[i++] << 8) | bytes[i++]);
+                imageData[j++] = (UInt16)((bytes[i++] << 8) | bytes[i++]); // Convert from network byte order (big endian)
             }
             return imageData;
         }

--- a/proknow-sdk/Patient/Entities/ImageSetItem.cs
+++ b/proknow-sdk/Patient/Entities/ImageSetItem.cs
@@ -65,7 +65,19 @@ namespace ProKnow.Patient.Entities
         /// </summary>
         /// <param name="index">The index of the image</param>
         /// <returns>The pixel data for the specified image</returns>
-        //todo--add example
+        /// <example>This example shows how to get the pixel data for an image:
+        /// <code>
+        /// using ProKnow;
+        /// using System.Threading.Tasks;
+        ///
+        /// var pk = new ProKnowApi("https://example.proknow.com", "./credentials.json");
+        /// var workspaceItem = await _proKnow.Workspaces.FindAsync(w => w.Name == "Clinical");
+        /// var patientSummary = await _proKnow.Patients.FindAsync(workspaceItem.Id, p => p.Name == "Example");
+        /// var patientItem = await patientSummary.GetAsync();
+        /// var imageSetItem = patientItem.FindEntities(e => e.Type == "image_set")[0];
+        /// var imageData = await imageSetItem.GetImageDataAsync(0);
+        /// </code>
+        /// </example>
         public async Task<UInt16[]> GetImageDataAsync(int index)
         {
             var image = Data.Images[index];

--- a/proknow-sdk/proknow-sdk.csproj
+++ b/proknow-sdk/proknow-sdk.csproj
@@ -8,7 +8,7 @@
     <Company>Elekta</Company>
     <Product>ProKnow</Product>
     <PackageId>ProKnow</PackageId>
-    <Version>0.0.23</Version>
+    <Version>0.0.24</Version>
     <Authors>ProKnow</Authors>
     <Description>ProKnow.NET SDK is a .NET Standard client and a portable class library for ProKnow</Description>
     <RepositoryUrl>https://github.com/proknow/proknow-sdk-dotnet</RepositoryUrl>


### PR DESCRIPTION
- Add GetSliceDataAsync method to DoseItem class to retrieve voxel data (DoseSlice)
- Add DoseData property to DoseItem class to provide dose properties
- Modify GetImageDataAsync method of ImageSetItem class to return UInt16[] instead of byte[]
- Modify Position property of ImageSetItem to be mm instead of 1/1000 mm
