### PR TITLE
Fix error uploading duplicate objects and improve upload performance

### DIFF
--- a/docs/releaseHistory.md
+++ b/docs/releaseHistory.md
@@ -4,6 +4,15 @@
 
 All releases in the v0.x.x series are subject to breaking changes from one version to another.  After the release of v1.0.0, this project will be subject to [semantic versioning](http://semver.org/).
 
+## v0.0.29
+
+*Bug Fixes and Enhancements*
+
+- Fix error uploading duplicate objects
+- Improve upload performance
+- When uploading, don't return an UploadBatch unless waiting for processing to complete
+- Throw an exception if, even after retrying, there are still unresolved uploads
+
 ## v0.0.28
 
 *Bug Fixes*

--- a/proknow-sdk-test/TestData/DuplicateObjects/RD - Copy.dcm
+++ b/proknow-sdk-test/TestData/DuplicateObjects/RD - Copy.dcm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c0a7e81fc09c223f7fe47a59771f42dc68916cb531ecf64766fcaf9f9b9a1be
+size 9888

--- a/proknow-sdk-test/TestData/DuplicateObjects/RD.dcm
+++ b/proknow-sdk-test/TestData/DuplicateObjects/RD.dcm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c0a7e81fc09c223f7fe47a59771f42dc68916cb531ecf64766fcaf9f9b9a1be
+size 9888

--- a/proknow-sdk-test/proknow-sdk-test.csproj
+++ b/proknow-sdk-test/proknow-sdk-test.csproj
@@ -53,6 +53,12 @@
     <None Update="TestData\dummy.pdf">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="TestData\DuplicateObjects\RD - Copy.dcm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TestData\DuplicateObjects\RD.dcm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="TestData\not_credentials.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/proknow-sdk/proknow-sdk.csproj
+++ b/proknow-sdk/proknow-sdk.csproj
@@ -8,7 +8,7 @@
     <Company>Elekta</Company>
     <Product>ProKnow</Product>
     <PackageId>ProKnow</PackageId>
-    <Version>0.0.28</Version>
+    <Version>0.0.29</Version>
     <Authors>ProKnow</Authors>
     <Description>ProKnow.NET SDK is a .NET Standard client and a portable class library for ProKnow</Description>
     <RepositoryUrl>https://github.com/proknow/proknow-sdk-dotnet</RepositoryUrl>


### PR DESCRIPTION
- Don't return UploadBatch unless waiting for processing to complete
- Make sure the filename in the upload results is the requested one since ProKnow returns the original  in case of duplicate objects
- Don't update query parameters and wait unless there are still unresolved uploads
- Throw an exception if, even after retrying, there are still unresolved uploads