### PR TITLE
Improve retrieval of upload processing results

### DIFF
--- a/docs/releaseHistory.md
+++ b/docs/releaseHistory.md
@@ -11,7 +11,12 @@ All releases in the v0.x.x series are subject to breaking changes from one versi
 - Enable user configuration of retry delays for waiting for ProKnow upload processing through the Uploads RetryDelays property
 - Set default retry delays to five 200 msec delays followed by 29 1000 msec delays for a total retry delay of 30 sec
 - Fix bug where an upload processing result is occasionally missed
-- In GetUploadProcessingResultsAsync, don't throw an exception if any uploads don't reach a terminal state, just return all results
+- For GetUploadProcessingResultsAsync:
+    - Modify the return to be an UploadProcessingResults class object that includes:
+        - The list of UploadProcessingResult for each upload
+        - A flag indicating whether the retry delays were exhausted
+        - The total retry delay
+    - Don't throw an exception if any uploads don't reach a terminal state, just include those uploads in the list with the status of "processing"
 
 ## v0.1.0
 

--- a/docs/releaseHistory.md
+++ b/docs/releaseHistory.md
@@ -4,6 +4,15 @@
 
 All releases in the v0.x.x series are subject to breaking changes from one version to another.  After the release of v1.0.0, this project will be subject to [semantic versioning](http://semver.org/).
 
+## v0.1.1
+
+*Bug Fixes and Enhancements*
+
+- Enable user configuration of retry delays for waiting for ProKnow upload processing through the Uploads RetryDelays property
+- Set default retry delays to five 200 msec delays followed by 29 1000 msec delays for a total retry delay of 30 sec
+- Fix bug where an upload processing result is occasionally missed
+- In GetUploadProcessingResultsAsync, don't throw an exception if any uploads don't reach a terminal state, just return all results
+
 ## v0.1.0
 
 *Enhancements*

--- a/proknow-sdk-test/TestData/Dose/RD.Large.dcm
+++ b/proknow-sdk-test/TestData/Dose/RD.Large.dcm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f90307347d6bbbab8f9c2308c7dedba6958b92da12dd360d504a9595daad930
+size 238944506

--- a/proknow-sdk-test/TestData/StructureSet/RS.Large.dcm
+++ b/proknow-sdk-test/TestData/StructureSet/RS.Large.dcm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3831a0355b24159627ea32adfffc74ccbbf60b5c84c4cdf01eec6f61bd0a89ed
+size 14714544

--- a/proknow-sdk-test/UploadTest/UploadBatchTest.cs
+++ b/proknow-sdk-test/UploadTest/UploadBatchTest.cs
@@ -48,7 +48,7 @@ namespace ProKnow.Upload.Test
             };
             var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, uploadPaths, overrides);
             var uploadProcessingResults = await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
-            var uploadBatch = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults);
+            var uploadBatch = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults.Results);
 
             // Get the summary view of the patient in the upload response
             var uploadPatientSummary = uploadBatch.FindPatient(mrUploadPath);
@@ -96,7 +96,7 @@ namespace ProKnow.Upload.Test
             };
             var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, uploadPath, overrides);
             var uploadProcessingResults = await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
-            var uploadBatch = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults);
+            var uploadBatch = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults.Results);
 
             // Get the summary views of the patient and an entity in the upload response
             var uploadPatientSummary = uploadBatch.FindPatient(uploadPath);
@@ -128,7 +128,7 @@ namespace ProKnow.Upload.Test
             };
             var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, uploadPath, overrides);
             var uploadProcessingResults = await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
-            var uploadBatch = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults);
+            var uploadBatch = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults.Results);
 
             // Get the summary views of the patient and the SRO in the upload response
             var uploadPatientSummary = uploadBatch.FindPatient(uploadPath);
@@ -154,7 +154,7 @@ namespace ProKnow.Upload.Test
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Sro", "reg.dcm");
             var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, uploadPath);
             var uploadProcessingResults = await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
-            var uploadBatch = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults);
+            var uploadBatch = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults.Results);
 
             // Verify the status
             Assert.AreEqual("completed", uploadBatch.GetStatus(uploadPath));
@@ -172,7 +172,7 @@ namespace ProKnow.Upload.Test
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "PatientNameConflict");
             var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, uploadPath);
             var uploadProcessingResults = await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
-            var uploadBatch = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults);
+            var uploadBatch = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults.Results);
 
             // Verify that one of the two files shows a status of "pending" (conflict)
             var uploadPath1 = Path.Combine(TestSettings.TestDataRootDirectory, "PatientNameConflict", "CT.1.dcm");
@@ -195,7 +195,7 @@ namespace ProKnow.Upload.Test
             var uploadPath2 = Path.Combine(TestSettings.TestDataRootDirectory, "PatientNameConflict", "CT.2.dcm");
             var uploadResults2 = await _proKnow.Uploads.UploadAsync(workspaceItem, uploadPath2);
             var uploadProcessingResults2 = await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults2);
-            var uploadBatch2 = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults2);
+            var uploadBatch2 = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults2.Results);
 
             // Verify that the second file shows a status of "pending" (conflict)
             Assert.IsTrue(uploadBatch2.GetStatus(uploadPath2) == "pending");
@@ -213,7 +213,7 @@ namespace ProKnow.Upload.Test
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "RtImage", "RTIMAGE.dcm");
             var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, uploadPath);
             var uploadProcessingResults = await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
-            var uploadBatch = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults);
+            var uploadBatch = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults.Results);
 
             // Verify the status
             Assert.AreEqual("failed", uploadBatch.GetStatus(uploadPath));
@@ -235,7 +235,7 @@ namespace ProKnow.Upload.Test
             // Upload the same data again
             var uploadResults2 = await _proKnow.Uploads.UploadAsync(workspaceItem, uploadPath);
             var uploadProcessingResults2 = await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults2);
-            var uploadBatch2 = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults2);
+            var uploadBatch2 = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults2.Results);
 
             // Verify the status is still "completed"
             Assert.AreEqual("completed", uploadBatch2.GetStatus(uploadPath));

--- a/proknow-sdk-test/UploadTest/UploadEntitySummaryTest.cs
+++ b/proknow-sdk-test/UploadTest/UploadEntitySummaryTest.cs
@@ -45,7 +45,7 @@ namespace ProKnow.Upload.Test
             };
             var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, uploadPath, overrides);
             var uploadProcessingResults = await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
-            var uploadBatch = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults);
+            var uploadBatch = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults.Results);
 
             // Get the summary views of the patient and entity in the upload response
             var uploadPatientSummary = uploadBatch.FindPatient(uploadPath);

--- a/proknow-sdk-test/UploadTest/UploadPatientSummaryTest.cs
+++ b/proknow-sdk-test/UploadTest/UploadPatientSummaryTest.cs
@@ -44,7 +44,7 @@ namespace ProKnow.Upload.Test
             };
             var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, uploadPath, overrides);
             var uploadProcessingResults = await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
-            var uploadBatch = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults);
+            var uploadBatch = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults.Results);
 
             // Get the summary view of the patient in the upload response
             var uploadPatientSummary = uploadBatch.FindPatient(uploadPath);

--- a/proknow-sdk-test/UploadTest/UploadSroSummaryTest.cs
+++ b/proknow-sdk-test/UploadTest/UploadSroSummaryTest.cs
@@ -44,7 +44,7 @@ namespace ProKnow.Upload.Test
             };
             var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, uploadPath, overrides);
             var uploadProcessingResults = await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
-            var uploadBatch = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults);
+            var uploadBatch = new UploadBatch(_proKnow, workspaceItem.Id, uploadProcessingResults.Results);
 
             // Get the summary views of the patient, entities, and SRO in the upload response
             var uploadPatientSummary = uploadBatch.FindPatient(Path.Combine(uploadPath, "reg.dcm"));

--- a/proknow-sdk-test/proknow-sdk-test.csproj
+++ b/proknow-sdk-test/proknow-sdk-test.csproj
@@ -50,6 +50,9 @@
     <None Update="TestData\bogus_credentials.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="TestData\Dose\RD.Large.dcm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="TestData\dummy.pdf">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -80,13 +83,16 @@
     <None Update="TestData\Sro\reg.dcm">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="TestData\StructureSet\RS.Large.dcm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="TestData\StructureSet\RS.Points.dcm">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="TestData\StructureSet\" />
+    <Folder Include="TestData\Dose\" />
     <Folder Include="TestData\Sro\" />
   </ItemGroup>
 

--- a/proknow-sdk/Upload/IUploads.cs
+++ b/proknow-sdk/Upload/IUploads.cs
@@ -178,8 +178,9 @@ namespace ProKnow.Upload
         /// <param name="uploadResults">The upload results for each file</param>
         /// <returns>The processing results for each file</returns>
         /// <remarks>
-        /// <para>The return value of this method can be used to construct an <see cref="UploadBatch"/> which can be used to
-        /// look up patients, entities, spatial registration objects, and file statuses within the processing results.</para>
+        /// <para>The Results property of the return value of this method can be used to construct an <see cref="UploadBatch"/>
+        /// which can be used to look up patients, entities, spatial registration objects, and file statuses within the processing
+        /// results.</para>
         /// <para>This overload is more performant than the one that takes a string workspace ProKnow ID or name because the
         /// workspace does not need to be resolved.</para>
         /// </remarks>
@@ -194,7 +195,7 @@ namespace ProKnow.Upload
         /// var uploadProcessingResults = await pk.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
         /// </code>
         /// </example>
-        Task<IList<UploadProcessingResult>> GetUploadProcessingResultsAsync(WorkspaceItem workspace, IList<UploadResult> uploadResults);
+        Task<UploadProcessingResults> GetUploadProcessingResultsAsync(WorkspaceItem workspace, IList<UploadResult> uploadResults);
 
         /// <summary>
         /// Gets the processing results for a provided set of uploads
@@ -204,8 +205,9 @@ namespace ProKnow.Upload
         /// <returns>The processing results for each file</returns>
         /// <exception cref="ProKnowWorkspaceLookupException">If no matching workspace was found</exception>
         /// <remarks>
-        /// <para>The return value of this method can be used to construct an <see cref="UploadBatch"/> which can be used to
-        /// look up patients, entities, spatial registration objects, and file statuses within the processing results.</para>
+        /// <para>The Results property of the return value of this method can be used to construct an <see cref="UploadBatch"/>
+        /// which can be used to look up patients, entities, spatial registration objects, and file statuses within the processing
+        /// results.</para>
         /// <para>This overload is less performant than the one that takes a workspace item because the workspace needs to be
         /// resolved.</para>
         /// </remarks>
@@ -219,6 +221,6 @@ namespace ProKnow.Upload
         /// var uploadProcessingResults = await pk.Uploads.GetUploadProcessingResultsAsync("Upload Test", uploadResults);
         /// </code>
         /// </example>
-        Task<IList<UploadProcessingResult>> GetUploadProcessingResultsAsync(string workspaceId, IList<UploadResult> uploadResults);
+        Task<UploadProcessingResults> GetUploadProcessingResultsAsync(string workspaceId, IList<UploadResult> uploadResults);
     }
 }

--- a/proknow-sdk/Upload/IUploads.cs
+++ b/proknow-sdk/Upload/IUploads.cs
@@ -10,6 +10,11 @@ namespace ProKnow.Upload
     public interface IUploads
     {
         /// <summary>
+        /// The retry delays in milliseconds for obtaining ProKnow upload processing results
+        /// </summary>
+        IList<int> RetryDelays { get; set; }
+
+        /// <summary>
         /// Upload file(s) asynchronously
         /// </summary>
         /// <param name="workspaceItem">The workspace</param>

--- a/proknow-sdk/Upload/UploadBatch.cs
+++ b/proknow-sdk/Upload/UploadBatch.cs
@@ -39,7 +39,7 @@ namespace ProKnow.Upload
         /// var workspaceItem = await pk.Workspaces.ResolveByNameAsync("Upload Test");
         /// var uploadResults = await pk.Uploads.UploadAsync(workspaceItem, "./DICOM");
         /// var uploadProcessingResults = await pk.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
-        /// var uploadBatch = new UploadBatch(pk, workspaceItem.Id, uploadProcessingResults);
+        /// var uploadBatch = new UploadBatch(pk, workspaceItem.Id, uploadProcessingResults.Results);
         /// </code>
         /// </example>
         public UploadBatch(ProKnowApi proKnow, string workspaceId, IList<UploadProcessingResult> uploadProcessingResults)

--- a/proknow-sdk/Upload/UploadProcessingResult.cs
+++ b/proknow-sdk/Upload/UploadProcessingResult.cs
@@ -31,6 +31,7 @@ namespace ProKnow.Upload
         /// "completed":  This object successfully completed processing
         /// "pending":  This object needs attention due to a conflict
         /// "failed":  This object failed to process
+        /// "processing":  This object did not complete processing before retry delays were exhausted
         /// </summary>
         [JsonPropertyName("status")]
         public string Status { get; set; }

--- a/proknow-sdk/Upload/UploadProcessingResult.cs
+++ b/proknow-sdk/Upload/UploadProcessingResult.cs
@@ -70,5 +70,14 @@ namespace ProKnow.Upload
         /// </summary>
         [JsonExtensionData]
         public Dictionary<string, object> ExtensionData { get; set; }
+
+        /// <summary>
+        /// Provides a string representation of this object
+        /// </summary>
+        /// <returns>A string representation of this object</returns>
+        public override string ToString()
+        {
+            return $"{Id} {Path} {Status} {UpdatedAt}";
+        }
     }
 }

--- a/proknow-sdk/Upload/UploadProcessingResults.cs
+++ b/proknow-sdk/Upload/UploadProcessingResults.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace ProKnow.Upload
+{
+    /// <summary>
+    /// A container for upload processing results
+    /// </summary>
+    public class UploadProcessingResults
+    {
+        /// <summary>
+        /// The processing results for each upload
+        /// </summary>
+        public IList<UploadProcessingResult> Results { get; set; }
+
+        /// <summary>
+        /// The flag indicating whether retry delays were exhausted
+        /// </summary>
+        public bool WereRetryDelaysExhausted { get; set; }
+
+        /// <summary>
+        /// The total retry delay in milliseconds
+        /// </summary>
+        public int TotalRetryDelayInMsec { get; set; }
+    }
+}

--- a/proknow-sdk/Upload/UploadResult.cs
+++ b/proknow-sdk/Upload/UploadResult.cs
@@ -38,5 +38,14 @@ namespace ProKnow.Upload
             Path = path;
             Status = status;
         }
+
+        /// <summary>
+        /// Provides a string representation of this object
+        /// </summary>
+        /// <returns>A string representation of this object</returns>
+        public override string ToString()
+        {
+            return $"{Id} {Path} {Status}";
+        }
     }
 }

--- a/proknow-sdk/proknow-sdk.csproj
+++ b/proknow-sdk/proknow-sdk.csproj
@@ -8,7 +8,7 @@
     <Company>Elekta</Company>
     <Product>ProKnow</Product>
     <PackageId>ProKnow</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <Authors>ProKnow</Authors>
     <Description>ProKnow.NET SDK is a .NET Standard client and a portable class library for ProKnow</Description>
     <RepositoryUrl>https://github.com/proknow/proknow-sdk-dotnet</RepositoryUrl>


### PR DESCRIPTION
- Enable user configuration of retry delays for waiting for ProKnow upload processing through the Uploads RetryDelays property
- Set default retry delays to five 200 msec delays followed by 29 1000 msec delays for a total retry delay of 30 sec
- Fix bug where an upload processing result is occasionally missed
- In GetUploadProcessingResultsAsync, don't throw an exception if any uploads don't reach a terminal state, just return all results
