### PR TITLE
Fix bug handling more than 200 incomplete uploads

### DIFF
--- a/docs/releaseHistory.md
+++ b/docs/releaseHistory.md
@@ -4,6 +4,13 @@
 
 All releases in the v0.x.x series are subject to breaking changes from one version to another.  After the release of v1.0.0, this project will be subject to [semantic versioning](http://semver.org/).
 
+## v0.1.5
+
+*Bug Fixes and Enhancements*
+
+- Fix bug retrieving upload processing results when there are always 200 or more with non-terminal processing results (i.e., uploads that were initiated whose content was never uploaded)
+- Add more logging details when uploading
+
 ## v0.1.4
 
 *Enhancements*

--- a/proknow-sdk/proknow-sdk.csproj
+++ b/proknow-sdk/proknow-sdk.csproj
@@ -8,7 +8,7 @@
     <Company>Elekta</Company>
     <Product>ProKnow</Product>
     <PackageId>ProKnow</PackageId>
-    <Version>0.1.4</Version>
+    <Version>0.1.5</Version>
     <Authors>ProKnow</Authors>
     <Description>ProKnow.NET SDK is a .NET Standard client and a portable class library for ProKnow</Description>
     <RepositoryUrl>https://github.com/proknow/proknow-sdk-dotnet</RepositoryUrl>


### PR DESCRIPTION
- Fix bug retrieving upload processing results when there are always 200 or more with non-terminal processing results (i.e., uploads that were initiated whose content was never uploaded)
- Add more logging details when uploading
