### PR TITLE
[stories/US251851] [stories/US250009]

### DIFF
--- a/docs/releaseHistory.md
+++ b/docs/releaseHistory.md
@@ -8,7 +8,7 @@ All releases in the v0.x.x series are subject to breaking changes from one versi
 
 *Enhancements*
 
-- Include patient ID in UploadFileOverrides
+- Include patient ProKnow ID in UploadFileOverrides
 - Append ".dcm" to downloaded image files
 
 ## v0.1.5

--- a/docs/releaseHistory.md
+++ b/docs/releaseHistory.md
@@ -4,6 +4,13 @@
 
 All releases in the v0.x.x series are subject to breaking changes from one version to another.  After the release of v1.0.0, this project will be subject to [semantic versioning](http://semver.org/).
 
+## v0.1.6
+
+*Enhancements*
+
+- Include patient ID in UploadFileOverrides
+- Append ".dcm" to downloaded image files
+
 ## v0.1.5
 
 *Bug Fixes and Enhancements*

--- a/proknow-sdk-test/PatientTest/EntitiesTest/ImageSetItemTest.cs
+++ b/proknow-sdk-test/PatientTest/EntitiesTest/ImageSetItemTest.cs
@@ -55,7 +55,7 @@ namespace ProKnow.Patient.Entities.Test
 
             // Check contents of one downloaded file (don't need to check them all!)
             var uploadedFile = Path.Combine(TestSettings.TestDataRootDirectory, "Becker^Matthew", "CT", "CT.1.dcm");
-            var downloadedFile = Path.Combine(downloadPath, $"CT.1.3.6.1.4.1.22213.2.26558.2.57");
+            var downloadedFile = Path.Combine(downloadPath, $"CT.1.3.6.1.4.1.22213.2.26558.2.57.dcm");
             Assert.IsTrue(TestHelper.FileEquals(uploadedFile, downloadedFile));
         }
 

--- a/proknow-sdk-test/PatientTest/EntitiesTest/StructureSetTest/StructureSetVersionItemTest.cs
+++ b/proknow-sdk-test/PatientTest/EntitiesTest/StructureSetTest/StructureSetVersionItemTest.cs
@@ -197,7 +197,7 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             // Upload it to a new patient and wait for it to be processed
             var overrides = new UploadFileOverrides
             {
-                Patient = new PatientCreateSchema { Mrn = $"{patientItem.Mrn}2", Name = $"{patientItem.Name}2" }
+                Patient = new PatientOverridesSchema { Mrn = $"{patientItem.Mrn}2", Name = $"{patientItem.Name}2" }
             };
             var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, actualDownloadPath, overrides);
             await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
@@ -249,7 +249,7 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             // Upload it to a new patient and wait for it to be processed
             var overrides = new UploadFileOverrides
             {
-                Patient = new PatientCreateSchema { Mrn = $"{patientItem.Mrn}2", Name = $"{patientItem.Name}2" }
+                Patient = new PatientOverridesSchema { Mrn = $"{patientItem.Mrn}2", Name = $"{patientItem.Name}2" }
             };
             var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, actualDownloadPath, overrides);
             await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
@@ -299,7 +299,7 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             // Upload it to a new patient and wait for it to be processed
             var overrides = new UploadFileOverrides
             {
-                Patient = new PatientCreateSchema { Mrn = $"{patientItem.Mrn}2", Name = $"{patientItem.Name}2" }
+                Patient = new PatientOverridesSchema { Mrn = $"{patientItem.Mrn}2", Name = $"{patientItem.Name}2" }
             };
             var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, actualDownloadPath, overrides);
             await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
@@ -349,7 +349,7 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
             // Upload it to a new patient and wait for it to be processed
             var overrides = new UploadFileOverrides
             {
-                Patient = new PatientCreateSchema { Mrn = $"{patientItem.Mrn}2", Name = $"{patientItem.Name}2" }
+                Patient = new PatientOverridesSchema { Mrn = $"{patientItem.Mrn}2", Name = $"{patientItem.Name}2" }
             };
             var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, actualDownloadPath, overrides);
             await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);

--- a/proknow-sdk-test/PatientTest/PatientItemTest.cs
+++ b/proknow-sdk-test/PatientTest/PatientItemTest.cs
@@ -161,7 +161,7 @@ namespace ProKnow.Patient.Test
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, Path.Combine("Becker^Matthew", "RS.dcm"));
             var overrides = new UploadFileOverrides
             {
-                Patient = new PatientCreateSchema { Mrn = patientItem.Mrn, Name = patientItem.Name }
+                Patient = new PatientOverridesSchema { Mrn = patientItem.Mrn, Name = patientItem.Name }
             };
             var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, uploadPath, overrides);
             await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
@@ -274,7 +274,7 @@ namespace ProKnow.Patient.Test
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Becker^Matthew", "RP.dcm");
             var overrides = new UploadFileOverrides
             {
-                Patient = new PatientCreateSchema { Mrn = patientItem.Mrn, Name = patientItem.Name }
+                Patient = new PatientOverridesSchema { Mrn = patientItem.Mrn, Name = patientItem.Name }
             };
             var uploadResults = await patientItem.UploadAsync(uploadPath, overrides);
             await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
@@ -300,7 +300,7 @@ namespace ProKnow.Patient.Test
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Becker^Matthew", "CT");
             var overrides = new UploadFileOverrides
             {
-                Patient = new PatientCreateSchema { Mrn = patientItem.Mrn, Name = patientItem.Name }
+                Patient = new PatientOverridesSchema { Mrn = patientItem.Mrn, Name = patientItem.Name }
             };
             var uploadResults = await patientItem.UploadAsync(uploadPath, overrides);
             await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
@@ -330,7 +330,7 @@ namespace ProKnow.Patient.Test
             var uploadPaths = new List<string>() { uploadPath1, uploadPath2 };
             var overrides = new UploadFileOverrides
             {
-                Patient = new PatientCreateSchema { Mrn = patientItem.Mrn, Name = patientItem.Name }
+                Patient = new PatientOverridesSchema { Mrn = patientItem.Mrn, Name = patientItem.Name }
             };
             var uploadResults = await patientItem.UploadAsync(uploadPaths, overrides);
             await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);

--- a/proknow-sdk-test/PatientTest/PatientSummaryTest.cs
+++ b/proknow-sdk-test/PatientTest/PatientSummaryTest.cs
@@ -69,7 +69,7 @@ namespace ProKnow.Patient.Test
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Becker^Matthew", "RP.dcm");
             var overrides = new UploadFileOverrides
             {
-                Patient = new PatientCreateSchema { Name = patientItem.Name, Mrn = patientItem.Mrn }
+                Patient = new PatientOverridesSchema { Name = patientItem.Name, Mrn = patientItem.Mrn }
             };
             var uploadResults = await patientSummary.UploadAsync(uploadPath, overrides);
             await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
@@ -97,7 +97,7 @@ namespace ProKnow.Patient.Test
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Becker^Matthew", "CT");
             var overrides = new UploadFileOverrides
             {
-                Patient = new PatientCreateSchema { Name = patientItem.Name, Mrn = patientItem.Mrn }
+                Patient = new PatientOverridesSchema { Name = patientItem.Name, Mrn = patientItem.Mrn }
             };
             var uploadResults = await patientSummary.UploadAsync(uploadPath, overrides);
             await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
@@ -129,7 +129,7 @@ namespace ProKnow.Patient.Test
             var uploadPaths = new List<string>() { uploadPath1, uploadPath2 };
             var overrides = new UploadFileOverrides
             {
-                Patient = new PatientCreateSchema { Name = patientItem.Name, Mrn = patientItem.Mrn }
+                Patient = new PatientOverridesSchema { Name = patientItem.Name, Mrn = patientItem.Mrn }
             };
             var uploadResults = await patientSummary.UploadAsync(uploadPaths, overrides);
             await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);

--- a/proknow-sdk-test/RequestorTest.cs
+++ b/proknow-sdk-test/RequestorTest.cs
@@ -95,6 +95,7 @@ namespace ProKnow.Test
             Assert.IsTrue(workspaceItems.Any(w => w.Name == workspaceItem.Name));
         }
 
+        [Ignore("There are no longer any GET routes that return anything other than the ProKnow index.html page when the status is not OK.")]
         [TestMethod]
         public async Task GetAsyncTest_NotOk()
         {

--- a/proknow-sdk-test/TestData/Jensen^Myrtle/CT/CT.1.dcm
+++ b/proknow-sdk-test/TestData/Jensen^Myrtle/CT/CT.1.dcm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b51deb0b6bf69c4dd40a54177568994c7e20bdad4f8b834e910d05a2273c335a
+size 525088

--- a/proknow-sdk-test/TestData/Jensen^Myrtle/CT/CT.2.dcm
+++ b/proknow-sdk-test/TestData/Jensen^Myrtle/CT/CT.2.dcm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f020aeb5ae06a6a4f8c4bb445abcbc9073ae73960af395ee08f39fdf29ead2af
+size 525088

--- a/proknow-sdk-test/TestData/Jensen^Myrtle/CT/CT.3.dcm
+++ b/proknow-sdk-test/TestData/Jensen^Myrtle/CT/CT.3.dcm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40d6026a9c97da6a21000918e9cd1737029b09552c72d3187da1442b2c6d3db5
+size 525088

--- a/proknow-sdk-test/TestData/Jensen^Myrtle/CT/CT.4.dcm
+++ b/proknow-sdk-test/TestData/Jensen^Myrtle/CT/CT.4.dcm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c52268979d1dd22ca281c83f59894820a050c9f661dd186c55d8779bf3446554
+size 525088

--- a/proknow-sdk-test/TestData/Jensen^Myrtle/CT/CT.5.dcm
+++ b/proknow-sdk-test/TestData/Jensen^Myrtle/CT/CT.5.dcm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2dd52250e1cf29538d1af663b8b0d8cee2a0ca2d02302e571dacd96bb142be87
+size 525088

--- a/proknow-sdk-test/TestData/Jensen^Myrtle/RD.dcm
+++ b/proknow-sdk-test/TestData/Jensen^Myrtle/RD.dcm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:581ecc68552170fb8d18a903f748b5ff1a19da3f8cdbcd308f88d7815e5e9849
+size 48316

--- a/proknow-sdk-test/TestData/Jensen^Myrtle/RP.dcm
+++ b/proknow-sdk-test/TestData/Jensen^Myrtle/RP.dcm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eda90e6a3a1b857b8859abfaf9e550eea3fce0b06c2902baac35403905a3a362
+size 10890

--- a/proknow-sdk-test/TestData/Jensen^Myrtle/RS.dcm
+++ b/proknow-sdk-test/TestData/Jensen^Myrtle/RS.dcm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2255de176dfc8bd2b0005dc0db533dd5b681e619763307a2695f36ae740bd865
+size 51942

--- a/proknow-sdk-test/TestHelper.cs
+++ b/proknow-sdk-test/TestHelper.cs
@@ -67,7 +67,7 @@ namespace ProKnow.Test
                 var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, testData);
                 var overrides = new UploadFileOverrides
                 {
-                    Patient = new PatientCreateSchema { Mrn = mrn, Name = name }
+                    Patient = new PatientOverridesSchema { Mrn = mrn, Name = name }
                 };
                 var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, uploadPath, overrides);
                 await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);

--- a/proknow-sdk-test/UploadTest/UploadBatchTest.cs
+++ b/proknow-sdk-test/UploadTest/UploadBatchTest.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using ProKnow.Patient;
 using ProKnow.Test;
 
 namespace ProKnow.Upload.Test
@@ -44,7 +43,7 @@ namespace ProKnow.Upload.Test
             var uploadPaths = new List<String>() { mrUploadPath, sroUploadPath };
             var overrides = new UploadFileOverrides
             {
-                Patient = new PatientCreateSchema { Mrn = $"{testNumber}-Mrn", Name = $"{testNumber}-Name" }
+                Patient = new PatientOverridesSchema { Mrn = $"{testNumber}-Mrn", Name = $"{testNumber}-Name" }
             };
             var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, uploadPaths, overrides);
             var uploadProcessingResults = await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
@@ -92,7 +91,7 @@ namespace ProKnow.Upload.Test
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Sro", "mr.dcm");
             var overrides = new UploadFileOverrides
             {
-                Patient = new PatientCreateSchema { Mrn = $"{testNumber}-Mrn", Name = $"{testNumber}-Name" }
+                Patient = new PatientOverridesSchema { Mrn = $"{testNumber}-Mrn", Name = $"{testNumber}-Name" }
             };
             var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, uploadPath, overrides);
             var uploadProcessingResults = await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);
@@ -124,7 +123,7 @@ namespace ProKnow.Upload.Test
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Sro", "reg.dcm");
             var overrides = new UploadFileOverrides
             {
-                Patient = new PatientCreateSchema { Mrn = $"{testNumber}-Mrn", Name = $"{testNumber}-Name" }
+                Patient = new PatientOverridesSchema { Mrn = $"{testNumber}-Mrn", Name = $"{testNumber}-Name" }
             };
             var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, uploadPath, overrides);
             var uploadProcessingResults = await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);

--- a/proknow-sdk-test/UploadTest/UploadEntitySummaryTest.cs
+++ b/proknow-sdk-test/UploadTest/UploadEntitySummaryTest.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ProKnow.Patient;
 using ProKnow.Patient.Entities;
 using ProKnow.Test;
 using System.IO;
@@ -41,7 +40,7 @@ namespace ProKnow.Upload.Test
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Sro", "ct.dcm");
             var overrides = new UploadFileOverrides
             {
-                Patient = new PatientCreateSchema { Mrn = $"{testNumber}-Mrn", Name = $"{testNumber}-Name" }
+                Patient = new PatientOverridesSchema { Mrn = $"{testNumber}-Mrn", Name = $"{testNumber}-Name" }
             };
             var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, uploadPath, overrides);
             var uploadProcessingResults = await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);

--- a/proknow-sdk-test/UploadTest/UploadPatientSummaryTest.cs
+++ b/proknow-sdk-test/UploadTest/UploadPatientSummaryTest.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ProKnow.Patient;
 using ProKnow.Test;
 using System.IO;
 using System.Threading.Tasks;
@@ -40,7 +39,7 @@ namespace ProKnow.Upload.Test
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Sro", "ct.dcm");
             var overrides = new UploadFileOverrides
             {
-                Patient = new PatientCreateSchema { Mrn = $"{testNumber}-Mrn", Name = $"{testNumber}-Name" }
+                Patient = new PatientOverridesSchema { Mrn = $"{testNumber}-Mrn", Name = $"{testNumber}-Name" }
             };
             var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, uploadPath, overrides);
             var uploadProcessingResults = await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);

--- a/proknow-sdk-test/UploadTest/UploadSroSummaryTest.cs
+++ b/proknow-sdk-test/UploadTest/UploadSroSummaryTest.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using ProKnow.Patient;
 using ProKnow.Test;
 using System.IO;
 using System.Threading.Tasks;
@@ -40,7 +39,7 @@ namespace ProKnow.Upload.Test
             var uploadPath = Path.Combine(TestSettings.TestDataRootDirectory, "Sro");
             var overrides = new UploadFileOverrides
             {
-                Patient = new PatientCreateSchema { Mrn = $"{testNumber}-Mrn", Name = $"{testNumber}-Name" }
+                Patient = new PatientOverridesSchema { Mrn = $"{testNumber}-Mrn", Name = $"{testNumber}-Name" }
             };
             var uploadResults = await _proKnow.Uploads.UploadAsync(workspaceItem, uploadPath, overrides);
             var uploadProcessingResults = await _proKnow.Uploads.GetUploadProcessingResultsAsync(workspaceItem, uploadResults);

--- a/proknow-sdk-test/proknow-sdk-test.csproj
+++ b/proknow-sdk-test/proknow-sdk-test.csproj
@@ -62,6 +62,30 @@
     <None Update="TestData\DuplicateObjects\RD.dcm">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="TestData\Jensen^Myrtle\CT\CT.1.dcm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TestData\Jensen^Myrtle\CT\CT.2.dcm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TestData\Jensen^Myrtle\CT\CT.3.dcm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TestData\Jensen^Myrtle\CT\CT.4.dcm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TestData\Jensen^Myrtle\CT\CT.5.dcm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TestData\Jensen^Myrtle\RD.dcm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TestData\Jensen^Myrtle\RP.dcm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TestData\Jensen^Myrtle\RS.dcm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="TestData\not_credentials.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/proknow-sdk/Patient/Entities/ImageSetItem.cs
+++ b/proknow-sdk/Patient/Entities/ImageSetItem.cs
@@ -50,7 +50,7 @@ namespace ProKnow.Patient.Entities
             var tasks = new List<Task<string>>();
             foreach (var image in Data.Images)
             {
-                var file = Path.Combine(folder, $"{Modality}.{image.Uid}");
+                var file = Path.Combine(folder, $"{Modality}.{image.Uid}.dcm");
                 var route = $"/workspaces/{WorkspaceId}/imagesets/{Id}/images/{image.Id}/dicom";
                 tasks.Add(Task.Run(() => _proKnow.Requestor.StreamAsync(route, file)));
             }

--- a/proknow-sdk/Upload/PatientOverridesSchema.cs
+++ b/proknow-sdk/Upload/PatientOverridesSchema.cs
@@ -8,19 +8,20 @@ namespace ProKnow.Upload
     public class PatientOverridesSchema
     {
         /// <summary>
-        /// The ProKnow ID for the patient
+        /// The ProKnow ID for the patient or null.  If present, this will be used for matching to an existing patient
         /// </summary>
         [JsonPropertyName("id")]
         public string Id { get; set; }
 
         /// <summary>
-        /// The patient medical record number (MRN) or ID
+        /// The patient medical record number (MRN) or DICOM patient ID (required).  This will be used for matching
+        /// to an existing patient if Id is not present
         /// </summary>
         [JsonPropertyName("mrn")]
         public string Mrn { get; set; }
 
         /// <summary>
-        /// The patient name
+        /// The patient name (required)
         /// </summary>
         [JsonPropertyName("name")]
         public string Name { get; set; }

--- a/proknow-sdk/Upload/PatientOverridesSchema.cs
+++ b/proknow-sdk/Upload/PatientOverridesSchema.cs
@@ -1,0 +1,40 @@
+﻿using System.Text.Json.Serialization;
+
+namespace ProKnow.Upload
+{
+    /// <summary>
+    /// Patient properties to override in a DICOM upload
+    /// </summary>
+    public class PatientOverridesSchema
+    {
+        /// <summary>
+        /// The ProKnow ID for the patient
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The patient medical record number (MRN) or ID
+        /// </summary>
+        [JsonPropertyName("mrn")]
+        public string Mrn { get; set; }
+
+        /// <summary>
+        /// The patient name
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The patient birth date in the format "YYYY-MM-DD" or null
+        /// </summary>
+        [JsonPropertyName("birth_date")]
+        public string BirthDate { get; set; }
+
+        /// <summary>
+        /// The patient sex, one of "M", "F", "O" or null
+        /// </summary>
+        [JsonPropertyName("sex")]
+        public string Sex { get; set; }
+    }
+}

--- a/proknow-sdk/Upload/UploadFileOverrides.cs
+++ b/proknow-sdk/Upload/UploadFileOverrides.cs
@@ -1,5 +1,4 @@
-﻿using ProKnow.Patient;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace ProKnow.Upload
 {
@@ -12,6 +11,6 @@ namespace ProKnow.Upload
         /// Patient overrides to be applied to an uploaded file
         /// </summary>
         [JsonPropertyName("patient")]
-        public PatientCreateSchema Patient { get; set; }
+        public PatientOverridesSchema Patient { get; set; }
     }
 }

--- a/proknow-sdk/proknow-sdk.csproj
+++ b/proknow-sdk/proknow-sdk.csproj
@@ -8,7 +8,7 @@
     <Company>Elekta</Company>
     <Product>ProKnow</Product>
     <PackageId>ProKnow</PackageId>
-    <Version>0.1.5</Version>
+    <Version>0.1.6</Version>
     <Authors>ProKnow</Authors>
     <Description>ProKnow.NET SDK is a .NET Standard client and a portable class library for ProKnow</Description>
     <RepositoryUrl>https://github.com/proknow/proknow-sdk-dotnet</RepositoryUrl>


### PR DESCRIPTION
 - Add patient ProKnow ID as upload override option (US251851)
     - Add new PatientOverridesSchema that is copy of PatientCreateSchema with additional Id
     - Replace PatientCreateSchema with PatientOverridesSchema in UploadFileOverrides
 - The default path for a downloaded image should include the .dcm extension (US250009)
 - Ignore Requestor test of functionality that can no longer be reached with current ProKnow
 - Modify test IgnoreAttributes to include reason for skipping test