### PR TITLE
[stories/PRK-2619] .NET SDK fails to get summary data for structure sets uploaded before RT Visualizer release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 credentials.json
 /proknow-sdk-test/TestEnvironment/pk-etc/
 /proknow-sdk-test/TestEnvironment/rtv-etc/
+hooks/
+lfs/
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/docs/releaseHistory.md
+++ b/docs/releaseHistory.md
@@ -4,6 +4,12 @@
 
 All releases in the v0.x.x series are subject to breaking changes from one version to another.  After the release of v1.0.0, this project will be subject to [semantic versioning](http://semver.org/).
 
+## v0.4.1
+
+*Bug Fixes*
+
+- Fixed issue with `EntitySummary.GetAsync` failing for structure sets uploaded to ProKnow prior to v2.0.2.0.
+
 ## v0.4.0
 
 *Enhancements*

--- a/proknow-sdk-test/PatientTest/EntitiesTest/StructureSetTest/StructureSetDataTest.cs
+++ b/proknow-sdk-test/PatientTest/EntitiesTest/StructureSetTest/StructureSetDataTest.cs
@@ -43,7 +43,7 @@ namespace ProKnow.Patient.Entities.StructureSet.Test
 
             Assert.AreEqual(3, structureSetData.Rois.Count());
             // Check Number rather than Name because the latter could be impacted by structure set renaming rules
-            var expectedNumbers = new int[] { 1, 2, 3 }.ToHashSet();
+            var expectedNumbers = new int?[] { 1, 2, 3 }.ToHashSet();
             var actualNumbers = structureSetData.Rois.Select(r => r.Number).ToHashSet();
             Assert.IsTrue(expectedNumbers.SetEquals(actualNumbers));
         }

--- a/proknow-sdk-test/TestEnvironment/docker-compose.yml
+++ b/proknow-sdk-test/TestEnvironment/docker-compose.yml
@@ -54,7 +54,7 @@ services:
   rt-visualizer:
     image: epgcr.azurecr.io/rt-visualizer:1.1.1
     ports:
-      - 8998:8988
+      - 8999:8988
     volumes:
       - rt-visualizer-cache:/etc/opt/rt-visualizer/cache/
       - ./rtv-etc:/etc/opt/rt-visualizer/config/

--- a/proknow-sdk-test/TestEnvironment/test-env-setup.ps1
+++ b/proknow-sdk-test/TestEnvironment/test-env-setup.ps1
@@ -55,7 +55,7 @@ if ($statusResponse.StatusCode -ne 200) {
     Write-Host "Failed to get status of ProKnow. Make sure to run 'docker-compose up -d' first. Status code: $($statusResponse.StatusCode)" -ForegroundColor Red
     exit 1
 }
-$statusResponse = Invoke-Url -Uri "http://localhost:8998/status"
+$statusResponse = Invoke-Url -Uri "http://localhost:8999/status"
 if ($statusResponse.StatusCode -ne 200) {
     Write-Host "Failed to get status of RTV. Make sure to run 'docker-compose up -d' first. Status code: $($statusResponse.StatusCode)" -ForegroundColor Red
     exit 1
@@ -76,7 +76,7 @@ if ($organizationsResponse.StatusCode -ne 200) {
 $organizations = $organizationsResponse.Content | ConvertFrom-Json
 $orgExists = $organizations | Where-Object { $_.name -eq ".NET SDK Testing" }
 if ($orgExists) {
-    Write-Host "`n.NET SDK Testing organization already exists. Exiting." -ForegroundColor Yellow
+    Write-Host "`.NET SDK Testing organization already exists. Exiting." -ForegroundColor Yellow
     Write-Output $orgExists
     exit 0
 }

--- a/proknow-sdk/Patient/Entities/StructureSet/StructureSetRoiItem.cs
+++ b/proknow-sdk/Patient/Entities/StructureSet/StructureSetRoiItem.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using ProKnow.Exceptions;
 using ProKnow.JsonConverters;
+using System;
 
 namespace ProKnow.Patient.Entities.StructureSet
 {
@@ -55,7 +56,7 @@ namespace ProKnow.Patient.Entities.StructureSet
         /// The number
         /// </summary>
         [JsonPropertyName("number")]
-        public int Number { get; set; }
+        public Nullable<int> Number { get; set; }
 
         /// <summary>
         /// The ProKnow tag

--- a/proknow-sdk/proknow-sdk.csproj
+++ b/proknow-sdk/proknow-sdk.csproj
@@ -8,7 +8,7 @@
     <Company>Elekta</Company>
     <Product>ProKnow</Product>
     <PackageId>ProKnow</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.4.1</Version>
     <Authors>ProKnow</Authors>
     <Description>ProKnow.NET SDK is a .NET Standard client and a portable class library for ProKnow</Description>
     <RepositoryUrl>https://github.com/proknow/proknow-sdk-dotnet</RepositoryUrl>


### PR DESCRIPTION
## Before requesting a reviewer, complete this checklist.

- [x] I have updated `releaseHistory.md`.
- [x] I have updated the `<Version>` attribute with the new version in `proknow-sdk.csproj` following the [semantic versioning](https://semver.org/) rules.
